### PR TITLE
Magento v1.x SOAP Customer and Order export

### DIFF
--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,3 +1,5 @@
+# Recommended rubocop version: ~> 0.56.0
+
 AllCops:
   Exclude:
   - 'db/schema.rb'
@@ -359,7 +361,7 @@ Style/RedundantReturn:
   AllowMultipleReturnValues: false
 
 Style/RegexpLiteral:
-  EnforcedStyle: slashes
+  EnforcedStyle: mixed
   SupportedStyles:
   - slashes
   - percent_r
@@ -767,7 +769,10 @@ Style/LineEndConcatenation:
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: true
+
+Style/MissingRespondToMissing:
   Enabled: true
 
 Style/MultilineBlockChain:

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/README.md
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/README.md
@@ -27,7 +27,9 @@ These environment variables are required, or the script will exit early with an 
 
 These variables are not required but can be used to customize the extraction process:
 
-* `LAST_INCREMENT_ID`: The increment ID to resume extracting from in case the script is interrupted and needs to be restarted
+* `LAST_KEY_ID`: The last ID to resume extracting from in case the script is interrupted and needs to be restarted
+
+
 
 ### Setting environment variables
 
@@ -66,7 +68,7 @@ ruby customers.rb
 
 Depending on how many objects are being extracted, there may be an initial delay while the collection of objects is being fetched before they are displayed to the console output.
 
-For 50, 000 objects it could take up to 5-10 minutes before the JSON data starts to be displayed.
+For 50, 000 objects it could take up to 5-10 minutes before the script starts to print out it's status.  While the script is running, the key ID of each object will be printed to your console on stderr.  Once all the objects have been exported then the entirety of the JSON data will be printed to stdout.  See below about redirecting just the JSON data to a file.
 
 ## Redirecting into a file
 
@@ -80,7 +82,9 @@ Afterwards, inspect that file to ensure that it contains valid JSON data and tha
 
 ## Resuming
 
-In the event that your export is interrupted, you can resume from where you left off by defining the optional `LAST_INCREMENT_ID` environment variable.
+In the event that your export is interrupted, you can resume from where you left off by defining the optional `LAST_KEY_ID` environment variable.
+
+For orders, the key is `increment_id` and for customers the key is `customer_id`.  Examine the output or file created by the previous attempt and export the value in the `LAST_KEY_ID` environment variable before resuming and previously exported objects will be skipped.
 
 *NOTE*: These scripts can take several hours to run for larger shops and are not yet capable of making concurrent requests.  Future versions may address this by performing some API calls in parallel.
 

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/README.md
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/README.md
@@ -2,7 +2,7 @@
 
 These are some sample scripts that demonstrate how objects can be exported from Magento.
 
-These command line tools look for specific environment variables that describe the Magento system being exported from then use the SOAP API to retrieve data and display JSON formatted data to the console/standard out.
+These command line tools look for specific environment variables that describe the Magento system being exported from. Next, they use the SOAP API to retrieve data and display JSON formatted data to the console/standard out.
 
 This output data is properly formatted to be supported as input into the Shopify Transporter Tool which then gets converted into CSV format used for uploading to the [Shopify Transporter App](https://apps.shopify.com/transporter).
 
@@ -12,11 +12,11 @@ These sample scripts currently target Magento version 1.x and use the SOAP API. 
 
 ## Setting up your environment
 
-To keep things simple and secure these sample scripts read environment variables for the input required to connect to Magento.
+To keep things simple and secure, these sample scripts read environment variables for the input required to connect to Magento.
 
-### Required 
+### Required
 
-These environment variables are required or the script will exit early with an error message:
+These environment variables are required, or the script will exit early with an error message:
 
 * `MAGENTO_SOAP_API_HOSTNAME`: The hostname of the Magento system
 * `MAGENTO_SOAP_API_USERNAME`: The username of the service account used to connect to the SOAP API
@@ -31,7 +31,7 @@ These variables are not required but can be used to customize the extraction pro
 
 ### Setting environment variables
 
-On a Unix-like system you can set environment variables using the export command:
+On a Unix-like system, you can set environment variables using the export command:
 
 ```
 export MAGENTO_SOAP_API_HOSTNAME=www.mystore.com
@@ -42,11 +42,11 @@ export MAGENTO_STORE_ID=1
 
 Of course, you will need to ensure you're using the appropriate values.  
 
-These environment variables will last the duration of your terminal or console session.  If you leave your terminal then you will need to redefine them.
+These environment variables will last the duration of your terminal or console session.  If you leave your terminal, then you will need to redefine them.
 
 ## Installing Required Gems
 
-The scripts are very light-weight and only have a single requirement: the [Savon SOAP library](http://savonrb.com/).
+The scripts are very lightweight and only have a single requirement: the [Savon SOAP library](http://savonrb.com/).
 
 You can install the gem with:
 
@@ -54,23 +54,23 @@ You can install the gem with:
 gem install savon
 ```
 
-After which you will be able to execute the scripts.
+after which you will be able to execute the scripts.
 
 ## Executing the extraction scripts
 
-Once you have defined your environment variables you can point ruby at the object script you want to run:
+Once you have defined your environment variables, you can point Ruby at the object script you want to run:
 
 ```
 ruby customers.rb
 ```
 
-Depending on the number of objects there will be an initial delay while the collection of objects is being fetched before they are displayed to the console output.
+Depending on how many objects are being extracted, there may be an initial delay while the collection of objects is being fetched before they are displayed to the console output.
 
 For 50, 000 objects it could take up to 5-10 minutes before the JSON data starts to be displayed.
 
 ## Redirecting into a file
 
-Until these scripts are enhanced to support specifying an output file you can redirect your console output from the script into a file using the `>` redirection approach.
+Until these scripts are enhanced to support specifying an output file, you can redirect the script's output into a file using the `>` redirection approach.
 
 ```
 ruby customers.rb > magento_customers.rb
@@ -86,4 +86,4 @@ In the event that your export is interrupted, you can resume from where you left
 
 ## Final steps
 
-Once you've generated your file you can use the Transporter Tools and follow the included documentation for getting started transforming the data into Shopify.
+Once you've generated your file, you can use the Transporter Tools to transform the data into a Shopify-friendly format. Follow the included documentation for getting started!

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/README.md
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/README.md
@@ -1,0 +1,89 @@
+# Magento v1.x Export Scripts
+
+These are some sample scripts that demonstrate how objects can be exported from Magento.
+
+These command line tools look for specific environment variables that describe the Magento system being exported from then use the SOAP API to retrieve data and display JSON formatted data to the console/standard out.
+
+This output data is properly formatted to be supported as input into the Shopify Transporter Tool which then gets converted into CSV format used for uploading to the [Shopify Transporter App](https://apps.shopify.com/transporter).
+
+## Supported Versions
+
+These sample scripts currently target Magento version 1.x and use the SOAP API.  You will need to ensure that you have a service account with a password capable of connecting to the Magento API before you begin.
+
+## Setting up your environment
+
+To keep things simple and secure these sample scripts read environment variables for the input required to connect to Magento.
+
+### Required 
+
+These environment variables are required or the script will exit early with an error message:
+
+* `MAGENTO_SOAP_API_HOSTNAME`: The hostname of the Magento system
+* `MAGENTO_SOAP_API_USERNAME`: The username of the service account used to connect to the SOAP API
+* `MAGENTO_SOAP_API_KEY`: The API key used to authenticate against the SOAP API
+* `MAGENTO_STORE_ID`: The store ID for multi-store Magento instances to extract data from
+
+### Optional
+
+These variables are not required but can be used to customize the extraction process:
+
+* `LAST_INCREMENT_ID`: The increment ID to resume extracting from in case the script is interrupted and needs to be restarted
+
+### Setting environment variables
+
+On a Unix-like system you can set environment variables using the export command:
+
+```
+export MAGENTO_SOAP_API_HOSTNAME=www.mystore.com
+export MAGENTO_SOAP_API_USERNAME=soapuser
+export MAGENTO_SOAP_API_KEY=sa231lds8asdf90121
+export MAGENTO_STORE_ID=1
+```
+
+Of course, you will need to ensure you're using the appropriate values.  
+
+These environment variables will last the duration of your terminal or console session.  If you leave your terminal then you will need to redefine them.
+
+## Installing Required Gems
+
+The scripts are very light-weight and only have a single requirement: the [Savon SOAP library](http://savonrb.com/).
+
+You can install the gem with:
+
+```
+gem install savon
+```
+
+After which you will be able to execute the scripts.
+
+## Executing the extraction scripts
+
+Once you have defined your environment variables you can point ruby at the object script you want to run:
+
+```
+ruby customers.rb
+```
+
+Depending on the number of objects there will be an initial delay while the collection of objects is being fetched before they are displayed to the console output.
+
+For 50, 000 objects it could take up to 5-10 minutes before the JSON data starts to be displayed.
+
+## Redirecting into a file
+
+Until these scripts are enhanced to support specifying an output file you can redirect your console output from the script into a file using the `>` redirection approach.
+
+```
+ruby customers.rb > magento_customers.rb
+```
+
+Afterwards, inspect that file to ensure that it contains valid JSON data and that the script didn't prematurely exit with a connection or other error.
+
+## Resuming
+
+In the event that your export is interrupted, you can resume from where you left off by defining the optional `LAST_INCREMENT_ID` environment variable.
+
+*NOTE*: These scripts can take several hours to run for larger shops and are not yet capable of making concurrent requests.  Future versions may address this by performing some API calls in parallel.
+
+## Final steps
+
+Once you've generated your file you can use the Transporter Tools and follow the included documentation for getting started transforming the data into Shopify.

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/customers.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/customers.rb
@@ -6,17 +6,25 @@ require_relative 'transporter_exporter.rb'
 
 class CustomerExporter < TransporterExporter
   def run
-    customers.each do |customer|
-      next if skip?(customer)
-
-      customer[:address_list] = customer_address_list(customer[:customer_id])
-      puts JSON.pretty_generate(customer)
-    end
+    puts JSON.pretty_generate(customers)
   end
 
   private
 
+  def key
+    :customer_id
+  end
+
   def customers
+    base_customers.each_with_object([]) do |customer, customers|
+      next if skip?(customer)
+
+      customers << customer.merge(address_list: customer_address_list(customer[:customer_id]))
+      $stderr.puts "fetched customer: #{customer[:customer_id]}"
+    end
+  end
+
+  def base_customers
     customers = soap_client.call(
       :customer_customer_list,
       message: {

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/customers.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/customers.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'savon'
+require 'json'
+
+require_relative 'transporter_exporter.rb'
+
+class CustomerExporter < TransporterExporter
+  def run
+    customers.each do |customer|
+      next if skip?(customer)
+
+      customer[:address_list] = customer_address_list(customer[:customer_id])
+      puts JSON.pretty_generate(customer)
+    end
+  end
+
+  private
+
+  def customers
+    customers = soap_client.call(
+      :customer_customer_list,
+      message: {
+        session_id: soap_session_id,
+      }
+    ).body
+
+    customers[:customer_customer_list_response][:store_view][:item].select do |customer|
+      customer[:store_id] == required_env_vars['MAGENTO_STORE_ID']
+    end
+  end
+
+  def customer_address_list(customer_id)
+    soap_client.call(
+      :customer_address_list,
+      message: { session_id: soap_session_id, customer_id: customer_id }
+    ).body
+  end
+end
+
+begin
+  CustomerExporter.new.run
+rescue TransporterExporter::ExportError => e
+  puts "error: #{e}"
+  exit(1)
+end

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/orders.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/orders.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'savon'
+require 'json'
+
+require_relative 'transporter_exporter'
+
+class OrderExporter < TransporterExporter
+  def run
+    orders_for(required_env_vars['MAGENTO_STORE_ID']).each do |order|
+      next if skip?(order)
+
+      puts JSON.pretty_generate(order.merge('items' => items_for(order)))
+    end
+  end
+
+  private
+
+  def orders
+    soap_client.call(
+      :sales_order_list,
+      message: { session_id: soap_session_id }
+    ).body[:sales_order_list_response][:result][:item]
+  end
+
+  def orders_for(store_id)
+    orders.select do |order|
+      order[:store_id] == store_id
+    end
+  end
+
+  def items_for(order)
+    soap_client.call(
+      :sales_order_info,
+      message: {
+        session_id: soap_session_id,
+        order_increment_id: order[:increment_id],
+      }
+    ).body[:sales_order_info_response]
+  end
+end
+
+begin
+  OrderExporter.new.run
+rescue TransporterExporter::ExportError => e
+  puts "error: #{e}"
+  exit(1)
+end

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/products.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/products.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require 'savon'
+require 'json'
+require 'pry'
+
+require_relative 'transporter_exporter.rb'
+class Observer
+
+  def notify(operation_name, builder, globals, locals)
+    puts builder.build_document
+  end
+
+end
+
+Savon.observers << Observer.new
+
+class ProductExporter < TransporterExporter
+  def run
+    #binding.pry
+    products = product_info(1)
+    #products = base_products
+    puts "before binding"
+    binding.pry
+  end
+
+  private
+
+  # The product ID of this is: 665548
+  def filters
+    {
+      filter: {
+        item: {
+          key: 'sku', 
+          value: 'RIP-HAU-GSHAW8-FA17',
+        }
+      }
+    }
+  end
+
+  # The product ID of the parent configurable is: 665548
+  def complex_filters 
+    {
+      complex_filter: [
+        item: [
+          {
+            key: 'sku',
+            value: {
+                key: 'like',
+                value: 'RIP-HAU-GSHAW8-FA17%',
+            }
+          },
+          {
+            key: 'type',
+            value: {
+                key: '=',
+                value: 'simple',
+            }
+          },
+        ] 
+      ]
+    }
+  end
+
+  def product_info(product_id)
+    soap_client.call(
+      :catalog_product_list,
+      message: { sessionId: soap_session_id, filters: filters}
+    ).body
+  end
+end
+
+begin
+  ProductExporter.new.run
+rescue TransporterExporter::ExportError => e
+  puts "error: #{e}"
+  exit(1)
+end

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/transporter_exporter.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/transporter_exporter.rb
@@ -33,15 +33,16 @@ class TransporterExporter
       wsdl: "https://#{required_env_vars['MAGENTO_SOAP_API_HOSTNAME']}/api/v2_soap?wsdl",
       open_timeout: 500,
       read_timeout: 500,
+      convert_request_keys_to: :none 
     )
   end
-
+  
   def soap_session_id
     @soap_session_id ||= soap_client.call(
       :login,
       message: {
         username: required_env_vars['MAGENTO_SOAP_API_USERNAME'],
-        api_key: required_env_vars['MAGENTO_SOAP_API_KEY'],
+        apiKey: required_env_vars['MAGENTO_SOAP_API_KEY'],
       }
     ).body[:login_response][:login_return]
   end

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/transporter_exporter.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/transporter_exporter.rb
@@ -15,6 +15,10 @@ class TransporterExporter
 
   private
 
+  def key
+    raise NotImplementedError
+  end
+
   REQUIRED_ENV_VARS = %w(
     MAGENTO_SOAP_API_HOSTNAME
     MAGENTO_SOAP_API_USERNAME
@@ -22,7 +26,7 @@ class TransporterExporter
     MAGENTO_STORE_ID
   ).freeze
 
-  OPTIONAL_ENV_VARS = %w(LAST_INCREMENT_ID).freeze
+  OPTIONAL_ENV_VARS = %w(LAST_KEY_ID).freeze
 
   def soap_client
     @soap_client ||= Savon.client(
@@ -43,9 +47,9 @@ class TransporterExporter
   end
 
   def skip?(item)
-    return false if optional_env_vars['LAST_INCREMENT_ID'].nil? || item[:incremenet_id].nil?
+    return false if optional_env_vars['LAST_KEY_ID'].nil? || item[key].nil?
 
-    item[:increment_id].to_i < optional_env_vars['LAST_INCREMENT_ID'].to_i
+    item[key].to_i < optional_env_vars['LAST_KEY_ID'].to_i
   end
 
   def write_to_file(filename, str)

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/transporter_exporter.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/soap_api/transporter_exporter.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require 'savon'
+require 'json'
+
+class TransporterExporter
+  class ExportError < StandardError
+    def initialize(message)
+      super(message)
+    end
+  end
+
+  def run
+    raise NotImplementedError
+  end
+
+  private
+
+  REQUIRED_ENV_VARS = %w(
+    MAGENTO_SOAP_API_HOSTNAME
+    MAGENTO_SOAP_API_USERNAME
+    MAGENTO_SOAP_API_KEY
+    MAGENTO_STORE_ID
+  ).freeze
+
+  OPTIONAL_ENV_VARS = %w(LAST_INCREMENT_ID).freeze
+
+  def soap_client
+    @soap_client ||= Savon.client(
+      wsdl: "https://#{required_env_vars['MAGENTO_SOAP_API_HOSTNAME']}/api/v2_soap?wsdl",
+      open_timeout: 500,
+      read_timeout: 500,
+    )
+  end
+
+  def soap_session_id
+    @soap_session_id ||= soap_client.call(
+      :login,
+      message: {
+        username: required_env_vars['MAGENTO_SOAP_API_USERNAME'],
+        api_key: required_env_vars['MAGENTO_SOAP_API_KEY'],
+      }
+    ).body[:login_response][:login_return]
+  end
+
+  def skip?(item)
+    return false if optional_env_vars['LAST_INCREMENT_ID'].nil? || item[:incremenet_id].nil?
+
+    item[:increment_id].to_i < optional_env_vars['LAST_INCREMENT_ID'].to_i
+  end
+
+  def write_to_file(filename, str)
+    open(filename, 'a') do |f|
+      flock(f, File::LOCK_EX) do |f_locked|
+        f_locked.puts str
+      end
+    end
+  end
+
+  def flock(file, mode)
+    success = file.flock(mode)
+    if success
+      begin
+        yield file
+      ensure
+        file.flock(File::LOCK_UN)
+      end
+    end
+  end
+
+  def required_env_vars
+    @required_env_vars ||= env_vars(REQUIRED_ENV_VARS, true)
+  end
+
+  def optional_env_vars
+    @optional_env_vars ||= env_vars(OPTIONAL_ENV_VARS, false)
+  end
+
+  def env_vars(vars, required = false)
+    vars.each_with_object({}) do |var, hash|
+      raise ExportError, "Missing environment variable: #{var}" if required && ENV[var].nil?
+      next if !required && ENV[var].nil?
+
+      hash[var] = ENV[var]
+    end
+  end
+end

--- a/sample_scripts/third_party_platform_exporting/magento/v1.9/transporter_exporter_spec.rb
+++ b/sample_scripts/third_party_platform_exporting/magento/v1.9/transporter_exporter_spec.rb
@@ -1,0 +1,9 @@
+ # frozen_string_literal: true
+
+RSpec.describe TransporterExporter do
+  context '#run' do
+    it 'raises NotImplementedError' do
+      expect{subject.new.run}.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/sample_scripts/third_party_platform_exporting/magento/v1.9/soap/transporter_exporter_spec.rb
+++ b/spec/sample_scripts/third_party_platform_exporting/magento/v1.9/soap/transporter_exporter_spec.rb
@@ -1,0 +1,9 @@
+ # frozen_string_literal: true
+
+RSpec.describe TransporterExporter do
+  context '#run' do
+    it 'raises NotImplementedError' do
+      expect{subject.new.run}.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
### What it does and why:
Provides sample scripts for exporting Magento v1.x customers and orders through the SOAP API.
### Checklist:

- [ ] Testing & QA: Passes tests and linting.
- [ ] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
