### PR TITLE
Extract product mappings from a magento database

### DIFF
--- a/lib/shopify_transporter.rb
+++ b/lib/shopify_transporter.rb
@@ -152,11 +152,11 @@ class TransporterTool
   def stage_class_from(name, type)
     class_name = stage_classname(name, type)
     klass = begin
-      k = Object.const_get(class_name)
-      k.is_a?(Class) && k
-    rescue NameError
-      nil
-    end
+              k = Object.const_get(class_name)
+              k.is_a?(Class) && k
+            rescue NameError
+              nil
+            end
     raise StageNotFoundError, name unless class_exists?(klass)
     klass
   end

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -10,7 +10,7 @@ module ShopifyTransporter
         end
 
         def export
-          $stderr.puts "Starting export..."
+          $stderr.puts 'Starting export...'
           base_products.compact
         end
 

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'sequel'
+
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      class ProductMappingExporter
+        BATCH_SIZE = 1000
+
+        def initialize(
+          database: '',
+          host: '',
+          port: 3306,
+          user: '',
+          password: '',
+          filename: 'magento_product_mappings.csv'
+        )
+          @host = host
+          @port = port
+          @user = user
+          @password = password
+          @filename = filename
+          @database = database
+        end
+
+        def extract_mappings
+          write_headers
+
+          Sequel.connect(
+            adapter: :mysql2, user: @user, password: @password, host: @host, port: @port, database: @database
+          ) do |db|
+            ordered_mappings = db
+              .from(:catalog_product_relation)
+              .order(:parent_id)
+            current_id = ordered_mappings.first[:parent_id]
+            max_id = ordered_mappings.last[:parent_id]
+
+            while current_id < max_id
+              mappings_batch = ordered_mappings.where(parent_id: current_id...(current_id + BATCH_SIZE))
+              write_data(mappings_batch)
+              current_id += BATCH_SIZE
+            end
+          end
+        end
+
+        private
+
+        def write_headers
+          File.open(@filename, 'w') do |file|
+            file << "product_id,associated_product_id\n"
+          end
+        end
+
+        def write_data(mappings)
+          File.open(@filename, 'a') do |file|
+            mappings.each do |mapping|
+              file << "#{mapping[:parent_id]},#{mapping[:child_id]}\n"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'sequel'
+require 'English'
 
 module ShopifyTransporter
   module Exporters
@@ -47,14 +48,14 @@ module ShopifyTransporter
 
         def write_headers
           File.open(@filename, 'w') do |file|
-            file << "product_id,associated_product_id\n"
+            file << "product_id,associated_product_id#{$INPUT_RECORD_SEPARATOR}"
           end
         end
 
         def write_data(mappings)
           File.open(@filename, 'a') do |file|
             mappings.each do |mapping|
-              file << "#{mapping[:parent_id]},#{mapping[:child_id]}\n"
+              file << "#{mapping[:parent_id]},#{mapping[:child_id]}#{$INPUT_RECORD_SEPARATOR}"
             end
           end
         end

--- a/shopify_transporter.gemspec
+++ b/shopify_transporter.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3'
 
   spec.add_dependency 'activesupport', '~> 5.1'
+  spec.add_dependency 'mysql2'
+  spec.add_dependency 'savon', '~> 2.12'
+  spec.add_dependency 'sequel', '~> 5.12'
   spec.add_dependency 'thor', '~> 0.20'
   spec.add_dependency 'yajl-ruby', '~> 1.3'
-  spec.add_dependency 'savon', '~> 2.12'
 end

--- a/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'shopify_transporter/pipeline/stage'
 
 module ShopifyTransporter
   module Exporters

--- a/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
@@ -175,7 +175,7 @@ module ShopifyTransporter
 
               expected_file_data = "product_id,associated_product_id\n"
               mappings.each do |mapping|
-                expected_file_data += "#{mapping[:parent_id]},#{mapping[:child_id]}\n"
+                expected_file_data += "#{mapping[:parent_id]},#{mapping[:child_id]}#{$INPUT_RECORD_SEPARATOR}"
               end
 
               expect(File.read(@tempfile.path)).to eq(expected_file_data)

--- a/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+require 'shopify_transporter/exporters/magento/product_mapping_exporter'
+
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      RSpec.describe ProductMappingExporter do
+        around :each do |example|
+          Tempfile.open('test_product_mappings.csv', Dir.tmpdir) do |file|
+            @tempfile = file
+            example.run
+          end
+        end
+
+        describe '#initialize' do
+          it 'initializes when provided the right values' do
+            described_class.new(
+              database: 'test',
+              host: '127.0.0.1',
+              port: 3306,
+              user: 'dbuser',
+              password: 'dbuserpassword',
+              filename: @tempfile.path
+            )
+          end
+        end
+
+        describe '#extract_mappings' do
+          it 'creates a new file' do
+            expect(Sequel).to receive(:connect)
+
+            File.open(@tempfile.path, 'w') do |file|
+              file << "test data"
+            end
+
+            exporter = described_class.new(
+              database: 'test',
+              host: '127.0.0.1',
+              port: 3306,
+              user: 'dbuser',
+              password: 'dbuserpassword',
+              filename: @tempfile.path
+            )
+
+            exporter.extract_mappings
+
+            expect(File.read(@tempfile.path)).to eq <<~EOS
+              product_id,associated_product_id
+              EOS
+          end
+
+          it 'writes the expected headers to the output file' do
+            expect(Sequel).to receive(:connect)
+
+            exporter = described_class.new(
+              database: 'test',
+              host: '127.0.0.1',
+              port: 3306,
+              user: 'dbuser',
+              password: 'dbuserpassword',
+              filename: @tempfile.path
+            )
+
+            exporter.extract_mappings
+
+            expect(File.read(@tempfile.path)).to eq <<~EOS
+              product_id,associated_product_id
+              EOS
+          end
+
+          it 'uses Sequel to connect to the MySQL database with the provided parameters' do
+            expect(Sequel).to receive(:connect).with(
+              adapter: :mysql2,
+              database: 'test',
+              host: '127.0.0.1',
+              port: 3306,
+              user: 'dbuser',
+              password: 'dbuserpassword',
+            )
+
+            exporter = described_class.new(
+              database: 'test',
+              host: '127.0.0.1',
+              port: 3306,
+              user: 'dbuser',
+              password: 'dbuserpassword',
+              filename: @tempfile.path
+            )
+
+            exporter.extract_mappings
+          end
+
+          describe 'fetching product batches and outputting to file' do
+            subject do
+              described_class.new(
+                database: 'test',
+                host: '127.0.0.1',
+                port: 3306,
+                user: 'dbuser',
+                password: 'dbuserpassword',
+                filename: @tempfile.path
+              )
+            end
+            let(:db) { double('sequel database connection') }
+            let(:mappings) { double('product mappings relation') }
+            let(:ordered_mappings) { double('ordered product mapping relation') }
+
+            let(:mappings) do
+              [
+                {
+                  parent_id: 1,
+                  child_id: 2,
+                },
+                {
+                  parent_id: 3,
+                  child_id: 4,
+                },
+                {
+                  parent_id: described_class::BATCH_SIZE,
+                  child_id: 5,
+                },
+                {
+                  parent_id: described_class::BATCH_SIZE + 1,
+                  child_id: 6,
+                },
+              ]
+            end
+
+            before :each do
+              expect(Sequel).to receive(:connect) do |&block|
+                block.call(db)
+              end
+            end
+
+            it 'fetches product mappings in batches from the database' do
+              expect(db).to receive(:from).and_return(mappings).ordered
+              expect(mappings).to receive(:order).with(:parent_id).and_return(ordered_mappings).ordered
+
+              expect(ordered_mappings).to receive(:first).and_return(parent_id: 1)
+              expect(ordered_mappings).to receive(:last).and_return(parent_id: 2 * described_class::BATCH_SIZE)
+
+              expect(ordered_mappings).to receive(:where).with(
+                parent_id: 1...(1 + described_class::BATCH_SIZE)
+              ).and_return(
+                mappings[0..1]
+              )
+              expect(ordered_mappings).to receive(:where).with(
+                parent_id: (1 + described_class::BATCH_SIZE)...(1 + 2 * described_class::BATCH_SIZE)
+              ).and_return(
+                mappings[2..3]
+              )
+
+              subject.extract_mappings
+            end
+
+            it 'writes product mappings to the external file specified' do
+              expect(db).to receive(:from).and_return(mappings).ordered
+              expect(mappings).to receive(:order).with(:parent_id).and_return(ordered_mappings).ordered
+
+              expect(ordered_mappings).to receive(:first).and_return(parent_id: 1)
+              expect(ordered_mappings).to receive(:last).and_return(parent_id: 2 * described_class::BATCH_SIZE)
+
+              expect(ordered_mappings).to receive(:where).with(
+                parent_id: 1...(1 + described_class::BATCH_SIZE)
+              ).and_return(
+                mappings[0..1]
+              )
+              expect(ordered_mappings).to receive(:where).with(
+                parent_id: (1 + described_class::BATCH_SIZE)...(1 + 2 * described_class::BATCH_SIZE)
+              ).and_return(
+                mappings[2..3]
+              )
+
+              subject.extract_mappings
+
+              expected_file_data = "product_id,associated_product_id\n"
+              mappings.each do |mapping|
+                expected_file_data += "#{mapping[:parent_id]},#{mapping[:child_id]}\n"
+              end
+
+              expect(File.read(@tempfile.path)).to eq(expected_file_data)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/shopify_transporter/pipeline/stage_spec.rb
+++ b/spec/shopify_transporter/pipeline/stage_spec.rb
@@ -10,5 +10,8 @@ module ShopifyTransporter::Pipeline
     it 'initializes with params' do
       expect { Stage.new('test_params') }.not_to raise_error
     end
+    it 'raises a NotImplementedError when Stage#convert is called' do
+      expect { Stage.new('test_params').convert({}, nil) }.to raise_error(NotImplementedError)
+    end
   end
 end

--- a/spec/shopify_transporter/shopify/record_spec.rb
+++ b/spec/shopify_transporter/shopify/record_spec.rb
@@ -17,6 +17,16 @@ module ShopifyTransporter
           expect{subject.new.to_csv}.to raise_error(NotImplementedError)
         end
       end
+
+      context 'static methods' do
+        it 'raises a NotImplementedError when calling Record#columns' do
+          expect { Record.columns }.to raise_error(NotImplementedError)
+        end
+
+        it 'raises a NotImplementedError when calling Record#keys' do
+          expect { Record.keys }.to raise_error(NotImplementedError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What it does and why:
- This is a work in progress script to extract product mappings from a magento database.
- This will be integrated in the data extraction process in the future.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.
