### PR TITLE
Add Magento 1.x exporter for basic product information 

### DIFF
--- a/exe/shopify_transporter
+++ b/exe/shopify_transporter
@@ -33,8 +33,8 @@ module ShopifyTransporter
     method_option :config, type: :string, default: 'config.yml',
       desc: 'The config file that describes the third party platform to export from.'
     method_option :object, type: :string, required: true,
-      desc: 'The object type (customer or order) to export.',
-      enum: %w(customer order)
+      desc: 'The object type (customer, product, or order) to export.',
+      enum: %w(customer product order)
 
     desc 'export', 'Exports objects from a third-party platform into a format compatible for conversion.'
     def export

--- a/lib/shopify_transporter/exporters/magento/magento_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/magento_exporter.rb
@@ -2,6 +2,7 @@
 
 require_relative './customer_exporter.rb'
 require_relative './order_exporter.rb'
+require_relative './product_exporter.rb'
 
 module ShopifyTransporter
   module Exporters
@@ -15,6 +16,8 @@ module ShopifyTransporter
             CustomerExporter
           when 'order'
             OrderExporter
+          when 'product'
+            ProductExporter
           else
             raise MissingExporterError
           end.new(store_id: store_id, client: client)

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry'
 
 module ShopifyTransporter
   module Exporters

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'pry'
+
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      class ProductExporter
+        def initialize(store_id: nil, client: nil)
+          @client = client
+          @store_id = store_id
+        end
+
+        def export
+          $stderr.puts "Starting export..."
+          base_products.map do |product|
+            $stderr.puts "Fetching product: #{product[:product_id]}..."
+            product.merge(product_info: info_for(product[:product_id]))
+          end.compact
+        end
+
+        private
+
+        def base_products
+          result = @client.call(:catalog_product_list, filters: nil).body
+          result[:catalog_product_list_response][:store_view][:item] || []
+        end
+
+        def info_for(product_id)
+          @client.call(:catalog_product_info, product_id: product_id).body[:catalog_product_info_response][:result]
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -12,10 +12,7 @@ module ShopifyTransporter
 
         def export
           $stderr.puts "Starting export..."
-          base_products.map do |product|
-            $stderr.puts "Fetching product: #{product[:product_id]}..."
-            product.merge(product_info: info_for(product[:product_id]))
-          end.compact
+          base_products.compact
         end
 
         private
@@ -23,10 +20,6 @@ module ShopifyTransporter
         def base_products
           result = @client.call(:catalog_product_list, filters: nil).body
           result[:catalog_product_list_response][:store_view][:item] || []
-        end
-
-        def info_for(product_id)
-          @client.call(:catalog_product_info, product_id: product_id).body[:catalog_product_info_response][:result]
         end
       end
     end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'shopify_transporter/pipeline/stage'
+
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      RSpec.describe ProductExporter do
+        context '#run' do
+          it 'retrieves products from Magento using the SOAP API and returns the results' do
+            soap_client = double("soap client")
+
+            catalog_product_list_response_body = double('catalog_product_list_response_body')
+            catalog_product_info_response_body = double('catalog_product_info_response_body')
+
+            expect(soap_client)
+              .to receive(:call).with(:catalog_product_list, anything)
+              .and_return(catalog_product_list_response_body)
+              .at_least(:once)
+
+            expect(catalog_product_list_response_body).to receive(:body).and_return(
+              catalog_product_list_response: {
+                store_view: {
+                  item: [
+                    {
+                      product_id: 12345,
+                      top_level_attribute: "an_attribute",
+                    },
+                  ],
+                },
+              },
+            ).at_least(:once)
+
+            expected_result = [
+              {
+                product_id: 12345,
+                top_level_attribute: "an_attribute",
+              },
+            ]
+
+            exporter = described_class.new(store_id: 1, client: soap_client)
+            expect(exporter.export).to eq(expected_result)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What it does and why:

Implements an exporter for top-level Product information.

Example output: 

https://pastebin.com/mh9Rnb08

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:

https://github.com/Shopify/transporter_app/issues/1266
