### PR TITLE
Associate configurable_products with their simple_products

### DIFF
--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -45,8 +45,8 @@ module ShopifyTransporter
           database: config['export_configuration']['database']['name'],
           hostname: config['export_configuration']['database']['hostname'],
           username: config['export_configuration']['database']['username'],
-          port: config['export_configuration']['database']['port']
-          password: config['export_configuration']['database']['password']
+          port: config['export_configuration']['database']['port'],
+          password: config['export_configuration']['database']['password'],
         )
       end
 

--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -18,14 +18,12 @@ module ShopifyTransporter
       end
 
       def run
-        client = Magento::Soap.new(
-          config['export_configuration']['soap']['hostname'],
-          config['export_configuration']['soap']['username'],
-          config['export_configuration']['soap']['api_key'],
-        )
-        store_id = config['export_configuration']['store_id']
-
-        data = Magento::MagentoExporter.for(type: object_type, store_id: store_id, client: client).export
+        data = Magento::MagentoExporter.for(
+          type: object_type,
+          store_id: config['export_configuration']['store_id'],
+          soap_client: soap_client,
+          database_adapter: database_adapter
+        ).export
 
         puts JSON.pretty_generate(data) + $INPUT_RECORD_SEPARATOR
       end
@@ -33,6 +31,24 @@ module ShopifyTransporter
       private
 
       attr_reader :config, :object_type
+
+      def soap_client
+        soap_client = Magento::Soap.new(
+          hostname: config['export_configuration']['soap']['hostname'],
+          username: config['export_configuration']['soap']['username'],
+          api_key: config['export_configuration']['soap']['api_key'],
+        )
+      end
+
+      def database_adapter
+        database_adapter = Magento::SQL.new(
+          database: config['export_configuration']['database']['name'],
+          hostname: config['export_configuration']['database']['hostname'],
+          username: config['export_configuration']['database']['username'],
+          port: config['export_configuration']['database']['port']
+          password: config['export_configuration']['database']['password']
+        )
+      end
 
       def load_config(config_filename)
         @config ||= begin

--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -59,13 +59,23 @@ module ShopifyTransporter
       end
 
       def ensure_config_has_required_keys
-        [
+        base_required_keys = [
           %w(export_configuration),
           %w(export_configuration soap hostname),
           %w(export_configuration soap username),
           %w(export_configuration soap api_key),
           %w(export_configuration store_id),
-        ].each do |keys|
+        ]
+
+        product_required_keys = [
+          %w(export_configuration database hostname),
+          %w(export_configuration database username),
+          %w(export_configuration database name),
+        ]
+
+        required_keys = base_required_keys + (@object_type == 'product' ? product_required_keys : [])
+
+        required_keys.each do |keys|
           raise InvalidConfigError, "missing required key '#{keys.last}'" unless config.dig(*keys)
         end
       end

--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -33,7 +33,7 @@ module ShopifyTransporter
       attr_reader :config, :object_type
 
       def soap_client
-        soap_client = Magento::Soap.new(
+        Magento::Soap.new(
           hostname: config['export_configuration']['soap']['hostname'],
           username: config['export_configuration']['soap']['username'],
           api_key: config['export_configuration']['soap']['api_key'],
@@ -41,7 +41,7 @@ module ShopifyTransporter
       end
 
       def database_adapter
-        database_adapter = Magento::SQL.new(
+        Magento::SQL.new(
           database: config['export_configuration']['database']['name'],
           hostname: config['export_configuration']['database']['hostname'],
           username: config['export_configuration']['database']['username'],

--- a/lib/shopify_transporter/exporters/magento.rb
+++ b/lib/shopify_transporter/exporters/magento.rb
@@ -2,3 +2,4 @@
 
 require_relative 'magento/magento_exporter.rb'
 require_relative 'magento/soap.rb'
+require_relative 'magento/sql.rb'

--- a/lib/shopify_transporter/exporters/magento/customer_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/customer_exporter.rb
@@ -4,8 +4,8 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class CustomerExporter
-        def initialize(store_id: nil, client: nil, database_adapter: nil)
-          @client = client
+        def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
+          @client = soap_client
           @store_id = store_id
         end
 

--- a/lib/shopify_transporter/exporters/magento/customer_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/customer_exporter.rb
@@ -7,6 +7,7 @@ module ShopifyTransporter
         def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
           @client = soap_client
           @store_id = store_id
+          @database_adapter = database_adapter
         end
 
         def export

--- a/lib/shopify_transporter/exporters/magento/customer_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/customer_exporter.rb
@@ -4,7 +4,7 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class CustomerExporter
-        def initialize(store_id: nil, client: nil)
+        def initialize(store_id: nil, client: nil, database_adapter: nil)
           @client = client
           @store_id = store_id
         end

--- a/lib/shopify_transporter/exporters/magento/magento_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/magento_exporter.rb
@@ -10,7 +10,7 @@ module ShopifyTransporter
       class MissingExporterError < ExportError; end
 
       class MagentoExporter
-        def self.for(type: nil, store_id: nil, client: nil)
+        def self.for(type: nil, store_id: nil, soap_client: nil, database_adapter: nil)
           case type
           when 'customer'
             CustomerExporter
@@ -20,7 +20,7 @@ module ShopifyTransporter
             ProductExporter
           else
             raise MissingExporterError
-          end.new(store_id: store_id, client: client)
+          end.new(store_id: store_id, soap_client: soap_client, database_adapter: database_adapter)
         end
       end
     end

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -4,8 +4,8 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class OrderExporter
-        def initialize(store_id: nil, client: nil, database_adapter: nil)
-          @client = client
+        def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
+          @client = soap_client
           @store_id = store_id
         end
 

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -4,7 +4,7 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class OrderExporter
-        def initialize(store_id: nil, client: nil)
+        def initialize(store_id: nil, client: nil, database_adapter: nil)
           @client = client
           @store_id = store_id
         end

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -7,6 +7,7 @@ module ShopifyTransporter
         def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
           @client = soap_client
           @store_id = store_id
+          @database_adapter = database_adapter
         end
 
         def export

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry'
 
 module ShopifyTransporter
   module Exporters

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -33,7 +33,8 @@ module ShopifyTransporter
 
         def apply_mappings(product_list)
           product_list.map do |product|
-            if product[:type] == 'configurable'
+            case product[:type]
+            when 'configurable'
               product.merge(simple_product_ids: product_mappings[product[:product_id]])
             else
               product

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -11,7 +11,7 @@ module ShopifyTransporter
         end
 
         def export
-          $stderr.puts "Starting export..."
+          $stderr.puts 'Starting export...'
           apply_mappings(base_products).compact
         end
 
@@ -24,7 +24,8 @@ module ShopifyTransporter
 
         def product_mappings
           @product_mappings ||= {}.tap do |product_mapping_table|
-            CSV.read("magento_product_mappings.csv").each do |(parent_id, child_id)| # TODO: generate and use real mapping file here!
+            # TODO: generate and use real mapping file here!
+            CSV.read('magento_product_mappings.csv').each do |(parent_id, child_id)|
               product_mapping_table[parent_id] ||= []
               product_mapping_table[parent_id] << child_id
             end

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -12,7 +12,7 @@ module ShopifyTransporter
 
         def export
           $stderr.puts "Starting export..."
-          apply_mappings(base_products, product_mappings).compact
+          apply_mappings(base_products).compact
         end
 
         private
@@ -23,18 +23,15 @@ module ShopifyTransporter
         end
 
         def product_mappings
-          # dummy. TODO: generate and use real mapping file here!
-          raw_mappings = CSV.read("magento_product_mappings.csv")
-
-          {}.tap do |table|
-            raw_mappings.each do |pair|
-              table[pair[0]] ||= []
-              table[pair[0]] << pair[1]
+          @product_mappings ||= {}.tap do |product_mapping_table|
+            CSV.read("magento_product_mappings.csv").each do |(parent_id, child_id)| # TODO: generate and use real mapping file here!
+              product_mapping_table[parent_id] ||= []
+              product_mapping_table[parent_id] << child_id
             end
           end
         end
 
-        def apply_mappings(product_list, product_mappings)
+        def apply_mappings(product_list)
           product_list.map do |product|
             if product[:type] == 'configurable'
               product.merge(simple_product_ids: product_mappings[product[:product_id]])

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -24,17 +24,14 @@ module ShopifyTransporter
 
         def product_mappings
           # dummy. TODO: generate and use real mapping file here!
-          x = CSV.read("magento_product_mappings.csv")
+          raw_mappings = CSV.read("magento_product_mappings.csv")
 
-          keys = x.map(&:first)
-
-          keys.map do |key|
-            values = []
-            x.each do |pair|
-              values << pair[1] if key == pair[0]
+          {}.tap do |table|
+            raw_mappings.each do |pair|
+              table[pair[0]] ||= []
+              table[pair[0]] << pair[1]
             end
-            [key, values]
-          end.to_h
+          end
         end
 
         def apply_mappings(product_list, product_mappings)

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -15,7 +15,7 @@ module ShopifyTransporter
 
         def export
           $stderr.puts 'Starting export...'
-          apply_mappings(base_products).compact
+          apply_mappings(base_products.compact)
         end
 
         private

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -24,8 +24,7 @@ module ShopifyTransporter
         end
 
         def product_mappings
-          # @database_adapter.extract_mappings_to_file(@intermediate_file_name)
-          product_mapping_exporter.extract_mappings
+          product_mapping_exporter.write_mappings(@intermediate_file_name)
 
           @product_mappings ||= {}.tap do |product_mapping_table|
             CSV.read(@intermediate_file_name).each do |(parent_id, child_id)|

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -30,8 +30,7 @@ module ShopifyTransporter
 
           @product_mappings ||= {}.tap do |product_mapping_table|
             CSV.read(@intermediate_file_name).each do |(parent_id, child_id)|
-              product_mapping_table[parent_id] ||= []
-              product_mapping_table[parent_id] << child_id
+              product_mapping_table[child_id] = parent_id
             end
           end
         end
@@ -43,8 +42,8 @@ module ShopifyTransporter
         def apply_mappings(product_list)
           product_list.map do |product|
             case product[:type]
-            when 'configurable'
-              product.merge(simple_product_ids: product_mappings[product[:product_id]])
+            when 'simple'
+              product.merge(parent_id: product_mappings[product[:product_id]])
             else
               product
             end

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -6,8 +6,8 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class ProductExporter
-        def initialize(store_id: nil, client: nil, database_adapter: nil)
-          @client = client
+        def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
+          @client = soap_client
           @store_id = store_id
           @intermediate_file_name = 'transporter/magento_product_mappings.csv'
           @database_adapter = database_adapter

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -43,11 +43,17 @@ module ShopifyTransporter
           product_list.map do |product|
             case product[:type]
             when 'simple'
-              product.merge(parent_id: product_mappings[product[:product_id]])
+              merge_simple_product_with_parent(product, product_mappings)
             else
               product
             end
           end
+        end
+
+        def merge_simple_product_with_parent(product, product_mappings)
+          return product unless product_mappings[product[:product_id]].present?
+
+          product.merge(parent_id: product_mappings[product[:product_id]])
         end
       end
     end

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -9,7 +9,7 @@ module ShopifyTransporter
         def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
           @client = soap_client
           @store_id = store_id
-          @intermediate_file_name = 'transporter/magento_product_mappings.csv'
+          @intermediate_file_name = 'magento_product_mappings.csv'
           @database_adapter = database_adapter
         end
 

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './product_mapping_exporter.rb'
+
 module ShopifyTransporter
   module Exporters
     module Magento
@@ -8,7 +10,7 @@ module ShopifyTransporter
           @client = client
           @store_id = store_id
           @intermediate_file_name = 'transporter/magento_product_mappings.csv'
-          @database_adapter: database_adapter
+          @database_adapter = database_adapter
         end
 
         def export
@@ -36,6 +38,7 @@ module ShopifyTransporter
 
         def product_mapping_exporter
           @product_mapping_exporter ||= ProductMappingExporter.new(database_adapter: @database_adapter)
+        end
 
         def apply_mappings(product_list)
           product_list.map do |product|

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -37,7 +37,7 @@ module ShopifyTransporter
         end
 
         def product_mapping_exporter
-          @product_mapping_exporter ||= ProductMappingExporter.new(database_adapter: @database_adapter)
+          @product_mapping_exporter ||= ProductMappingExporter.new(@database_adapter)
         end
 
         def apply_mappings(product_list)

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -12,8 +12,8 @@ module ShopifyTransporter
           @database_adapter = database_adapter
         end
 
-        def extract_mappings
-          write_headers
+        def write_mappings(filename)
+          write_headers(filename)
 
           @database_adapter do |db|
             ordered_mappings = db
@@ -24,7 +24,7 @@ module ShopifyTransporter
 
             while current_id < max_id
               mappings_batch = ordered_mappings.where(parent_id: current_id...(current_id + BATCH_SIZE))
-              write_data(mappings_batch)
+              write_data(mappings_batch, filename)
               current_id += BATCH_SIZE
             end
           end
@@ -32,14 +32,14 @@ module ShopifyTransporter
 
         private
 
-        def write_headers
-          File.open(@filename, 'w') do |file|
+        def write_headers(filename)
+          File.open(filename, 'w') do |file|
             file << "product_id,associated_product_id#{$INPUT_RECORD_SEPARATOR}"
           end
         end
 
-        def write_data(mappings)
-          File.open(@filename, 'a') do |file|
+        def write_data(mappings, filename)
+          File.open(filename, 'a') do |file|
             mappings.each do |mapping|
               file << "#{mapping[:parent_id]},#{mapping[:child_id]}#{$INPUT_RECORD_SEPARATOR}"
             end

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -8,7 +8,7 @@ module ShopifyTransporter
       class ProductMappingExporter
         BATCH_SIZE = 1000
 
-        def initialize(database_adapter: database_adapter)
+        def initialize(database_adapter: nil)
           @database_adapter = database_adapter
         end
 

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -8,7 +8,7 @@ module ShopifyTransporter
       class ProductMappingExporter
         BATCH_SIZE = 1000
 
-        def initialize(database_adapter: nil)
+        def initialize(database_adapter)
           @database_adapter = database_adapter
         end
 

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -15,7 +15,7 @@ module ShopifyTransporter
         def write_mappings(filename)
           write_headers(filename)
 
-          @database_adapter do |db|
+          @database_adapter.connect do |db|
             ordered_mappings = db
               .from(:catalog_product_relation)
               .order(:parent_id)

--- a/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_mapping_exporter.rb
@@ -8,28 +8,14 @@ module ShopifyTransporter
       class ProductMappingExporter
         BATCH_SIZE = 1000
 
-        def initialize(
-          database: '',
-          host: '',
-          port: 3306,
-          user: '',
-          password: '',
-          filename: 'magento_product_mappings.csv'
-        )
-          @host = host
-          @port = port
-          @user = user
-          @password = password
-          @filename = filename
-          @database = database
+        def initialize(database_adapter: database_adapter)
+          @database_adapter = database_adapter
         end
 
         def extract_mappings
           write_headers
 
-          Sequel.connect(
-            adapter: :mysql2, user: @user, password: @password, host: @host, port: @port, database: @database
-          ) do |db|
+          @database_adapter do |db|
             ordered_mappings = db
               .from(:catalog_product_relation)
               .order(:parent_id)

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -7,7 +7,7 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class Soap
-        def initialize(hostname, username, api_key)
+        def initialize(hostname: '', username: '', api_key: '')
           @hostname = hostname
           @username = username
           @api_key = api_key

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -10,7 +10,7 @@ module ShopifyTransporter
           host: '',
           port: 3306,
           username: '',
-          password: '',
+          password: ''
         )
 
           @database = database

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
-
 require 'sequel'
-require 'json'
 
 module ShopifyTransporter
   module Exporters

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'json'
+
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      class SQL
+        def initialize(
+          database: '',
+          host: '',
+          port: 3306,
+          username: '',
+          password: '',
+        )
+
+          @database = database
+          @host = host
+          @port = port
+          @username = username
+          @password = password
+        end
+
+        def connect
+          Sequel.connect(
+            adapter: :mysql2,
+            user: @username,
+            password: @password,
+            host: @host,
+            port: @port,
+            database: @database
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -20,8 +20,8 @@ module ShopifyTransporter
           @password = password
         end
 
-        def connect(&block)
-          block.call(Sequel.connect(
+        def connect
+          yield(Sequel.connect(
             adapter: :mysql2,
             user: @username,
             password: @password,

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -25,7 +25,7 @@ module ShopifyTransporter
             adapter: :mysql2,
             user: @username,
             password: @password,
-            host: @host,
+            host: @hostname,
             port: @port,
             database: @database
           )

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -20,15 +20,15 @@ module ShopifyTransporter
           @password = password
         end
 
-        def connect
-          Sequel.connect(
+        def connect(&block)
+          block.call(Sequel.connect(
             adapter: :mysql2,
             user: @username,
             password: @password,
             host: @hostname,
             port: @port,
             database: @database
-          )
+          ))
         end
       end
     end

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -7,14 +7,14 @@ module ShopifyTransporter
       class SQL
         def initialize(
           database: '',
-          host: '',
+          hostname: '',
           port: 3306,
           username: '',
           password: ''
         )
 
           @database = database
-          @host = host
+          @hostname = hostname
           @port = port
           @username = username
           @password = password

--- a/spec/shopify_transporter/exporters/exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/exporter_spec.rb
@@ -33,6 +33,13 @@ module ShopifyTransporter
               "username" => 'something',
               "api_key" => 'a_key',
             },
+            "database" => {
+              "hostname" => 'magento.host',
+              "username" => 'something',
+              "password" => 'a_password',
+              "port" => '1234',
+              "name" => 'testdatabase',
+            },
             "store_id" => 1,
           },
         }

--- a/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
@@ -52,7 +52,7 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, client: soap_client)
+            exporter = described_class.new(store_id: 1, soap_client: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
         end

--- a/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
@@ -21,7 +21,7 @@ module ShopifyTransporter
                 store_view: {
                   item: [
                     {
-                      customer_id: 654321,
+                      customer_id: '654321',
                       top_level_attribute: "an_attribute",
                     },
                   ],
@@ -31,7 +31,7 @@ module ShopifyTransporter
 
             expect(soap_client)
               .to receive(:call)
-              .with(:customer_address_list, customer_id: 654321)
+              .with(:customer_address_list, customer_id: '654321')
               .and_return(customer_address_list_response_body).at_least(:once)
 
             expect(customer_address_list_response_body).to receive(:body).and_return(
@@ -44,7 +44,7 @@ module ShopifyTransporter
 
             expected_result = [
               {
-                customer_id: 654321,
+                customer_id: '654321',
                 top_level_attribute: "an_attribute",
                 address_list: {
                   customer_address_attribute: "another_attribute",

--- a/spec/shopify_transporter/exporters/magento/magento_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/magento_exporter_spec.rb
@@ -4,28 +4,28 @@ require 'shopify_transporter/pipeline/stage'
 module ShopifyTransporter
   module Exporters
     module Magento
-      RSpec.describe ShopifyTransporter::Exporters::Magento::MagentoExporter do
+      RSpec.describe MagentoExporter do
         context '#for' do
           let(:fake_client) { double('fake_client') }
 
           it 'returns CustomerExporter for customer type' do
             expect(described_class.for(type: 'customer', store_id: 1, client: fake_client))
-              .to be_a(ShopifyTransporter::Exporters::Magento::CustomerExporter)
+              .to be_a(CustomerExporter)
           end
 
           it 'returns OrderExporter for order type' do
             expect(described_class.for(type: 'order', store_id: 1, client: fake_client))
-              .to be_a(ShopifyTransporter::Exporters::Magento::OrderExporter)
+              .to be_a(OrderExporter)
           end
 
           it 'returns ProductExporter for product type' do
             expect(described_class.for(type: 'product', store_id: 1, client: fake_client))
-              .to be_a(ShopifyTransporter::Exporters::Magento::ProductExporter)
+              .to be_a(ProductExporter)
           end
 
           it 'raises for any other type' do
             expect { described_class.for(type: 'nonexistent_type', store_id: 1, client: fake_client) }
-              .to raise_error(ShopifyTransporter::Exporters::Magento::MissingExporterError)
+              .to raise_error(MissingExporterError)
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/magento_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/magento_exporter_spec.rb
@@ -1,23 +1,34 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
 
-RSpec.describe ShopifyTransporter::Exporters::Magento::MagentoExporter do
-  context '#for' do
-    let(:fake_client) { double('fake_client') }
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      RSpec.describe ShopifyTransporter::Exporters::Magento::MagentoExporter do
+        context '#for' do
+          let(:fake_client) { double('fake_client') }
 
-    it 'returns CustomerExporter for customer type' do
-      expect(described_class.for(type: 'customer', store_id: 1, client: fake_client))
-        .to be_a(ShopifyTransporter::Exporters::Magento::CustomerExporter)
-    end
+          it 'returns CustomerExporter for customer type' do
+            expect(described_class.for(type: 'customer', store_id: 1, client: fake_client))
+              .to be_a(ShopifyTransporter::Exporters::Magento::CustomerExporter)
+          end
 
-    it 'returns OrderExporter for order type' do
-      expect(described_class.for(type: 'order', store_id: 1, client: fake_client))
-        .to be_a(ShopifyTransporter::Exporters::Magento::OrderExporter)
-    end
+          it 'returns OrderExporter for order type' do
+            expect(described_class.for(type: 'order', store_id: 1, client: fake_client))
+              .to be_a(ShopifyTransporter::Exporters::Magento::OrderExporter)
+          end
 
-    it 'raises for any other type' do
-      expect { described_class.for(type: 'nonexistent_type', store_id: 1, client: fake_client) }
-        .to raise_error(ShopifyTransporter::Exporters::Magento::MissingExporterError)
+          it 'returns ProductExporter for product type' do
+            expect(described_class.for(type: 'product', store_id: 1, client: fake_client))
+              .to be_a(ShopifyTransporter::Exporters::Magento::ProductExporter)
+          end
+
+          it 'raises for any other type' do
+            expect { described_class.for(type: 'nonexistent_type', store_id: 1, client: fake_client) }
+              .to raise_error(ShopifyTransporter::Exporters::Magento::MissingExporterError)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/shopify_transporter/exporters/magento/magento_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/magento_exporter_spec.rb
@@ -7,24 +7,25 @@ module ShopifyTransporter
       RSpec.describe MagentoExporter do
         context '#for' do
           let(:fake_client) { double('fake_client') }
+          let(:fake_adapter) { double('fake_adapter') }
 
           it 'returns CustomerExporter for customer type' do
-            expect(described_class.for(type: 'customer', store_id: 1, client: fake_client))
+            expect(described_class.for(type: 'customer', store_id: 1, soap_client: fake_client, database_adapter: fake_adapter))
               .to be_a(CustomerExporter)
           end
 
           it 'returns OrderExporter for order type' do
-            expect(described_class.for(type: 'order', store_id: 1, client: fake_client))
+            expect(described_class.for(type: 'order', store_id: 1, soap_client: fake_client, database_adapter: fake_adapter))
               .to be_a(OrderExporter)
           end
 
           it 'returns ProductExporter for product type' do
-            expect(described_class.for(type: 'product', store_id: 1, client: fake_client))
+            expect(described_class.for(type: 'product', store_id: 1, soap_client: fake_client, database_adapter: fake_adapter))
               .to be_a(ProductExporter)
           end
 
           it 'raises for any other type' do
-            expect { described_class.for(type: 'nonexistent_type', store_id: 1, client: fake_client) }
+            expect { described_class.for(type: 'nonexistent_type', store_id: 1, soap_client: fake_client, database_adapter: fake_adapter) }
               .to raise_error(MissingExporterError)
           end
         end

--- a/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
@@ -22,7 +22,7 @@ module ShopifyTransporter
                 result: {
                   item: [
                     {
-                      increment_id: 12345,
+                      increment_id: '12345',
                       top_level_attribute: "an_attribute",
                     },
                   ],
@@ -31,7 +31,7 @@ module ShopifyTransporter
             ).at_least(:once)
 
             expect(soap_client)
-              .to receive(:call).with(:sales_order_info, order_increment_id: 12345)
+              .to receive(:call).with(:sales_order_info, order_increment_id: '12345')
               .and_return(sales_order_info_response_body)
               .at_least(:once)
 
@@ -45,7 +45,7 @@ module ShopifyTransporter
 
             expected_result = [
               {
-                increment_id: 12345,
+                increment_id: '12345',
                 top_level_attribute: "an_attribute",
                 items: {
                   order_info_attribute: "another_attribute",

--- a/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
@@ -53,7 +53,7 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, client: soap_client)
+            exporter = described_class.new(store_id: 1, soap_client: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
         end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -6,7 +6,7 @@ module ShopifyTransporter
     module Magento
       RSpec.describe ProductExporter do
         context '#run' do
-          it 'retrieves products from Magento using the SOAP API and returns the results' do
+          it 'retrieves simple products from Magento using the SOAP API and returns the results' do
             soap_client = double("soap client")
 
             catalog_product_list_response_body = double('catalog_product_list_response_body')
@@ -22,7 +22,8 @@ module ShopifyTransporter
                 store_view: {
                   item: [
                     {
-                      product_id: 12345,
+                      product_id: '12345',
+                      type: 'simple',
                       top_level_attribute: "an_attribute",
                     },
                   ],
@@ -32,13 +33,64 @@ module ShopifyTransporter
 
             expected_result = [
               {
-                product_id: 12345,
+                product_id: '12345',
+                type: 'simple',
                 top_level_attribute: "an_attribute",
               },
             ]
 
             exporter = described_class.new(store_id: 1, client: soap_client)
             expect(exporter.export).to eq(expected_result)
+          end
+
+          it 'retrieves configurable products from Magento using the SOAP API and injects simple product ids' do
+            soap_client = double("soap client")
+
+            catalog_product_list_response_body = double('catalog_product_list_response_body')
+            catalog_product_info_response_body = double('catalog_product_info_response_body')
+
+            expect(soap_client)
+              .to receive(:call).with(:catalog_product_list, anything)
+              .and_return(catalog_product_list_response_body)
+              .at_least(:once)
+
+            expect(catalog_product_list_response_body).to receive(:body).and_return(
+              catalog_product_list_response: {
+                store_view: {
+                  item: [
+                    {
+                      product_id: '12345',
+                      type: 'configurable',
+                      top_level_attribute: "an_attribute",
+                    },
+                  ],
+                },
+              },
+            ).at_least(:once)
+
+            expected_result = [
+              {
+                product_id: '12345',
+                top_level_attribute: "an_attribute",
+                type: 'configurable',
+                simple_product_ids: ['800', '801', '802'],
+              },
+            ]
+
+            mappings = <<~EOS
+              product_id,associated_product_id
+              12345,800
+              12345,801
+              12345,802
+              67890,900
+              67890,901
+            EOS
+
+            in_temp_folder do
+              File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
+              exporter = described_class.new(store_id: 1, client: soap_client)
+              expect(exporter.export).to eq(expected_result)
+            end
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -6,7 +6,7 @@ module ShopifyTransporter
     module Magento
       RSpec.describe ProductExporter do
         context '#run' do
-          it 'retrieves simple products from Magento using the SOAP API and returns the results' do
+          it 'retrieves configurable products from Magento using the SOAP API and returns the results' do
             soap_client = double("soap client")
 
             catalog_product_list_response_body = double('catalog_product_list_response_body')
@@ -23,7 +23,7 @@ module ShopifyTransporter
                   item: [
                     {
                       product_id: '12345',
-                      type: 'simple',
+                      type: 'configurable',
                       top_level_attribute: "an_attribute",
                     },
                   ],
@@ -34,7 +34,7 @@ module ShopifyTransporter
             expected_result = [
               {
                 product_id: '12345',
-                type: 'simple',
+                type: 'configurable',
                 top_level_attribute: "an_attribute",
               },
             ]
@@ -43,7 +43,7 @@ module ShopifyTransporter
             expect(exporter.export).to eq(expected_result)
           end
 
-          it 'retrieves configurable products from Magento using the SOAP API and injects simple product ids' do
+          it 'retrieves simple products from Magento using the SOAP API and injects parent_id' do
             soap_client = double("soap client")
             product_mapping_exporter = double("product_mapping_exporter")
 
@@ -63,8 +63,8 @@ module ShopifyTransporter
                 store_view: {
                   item: [
                     {
-                      product_id: '12345',
-                      type: 'configurable',
+                      product_id: '801',
+                      type: 'simple',
                       top_level_attribute: "an_attribute",
                     },
                   ],
@@ -74,10 +74,10 @@ module ShopifyTransporter
 
             expected_result = [
               {
-                product_id: '12345',
+                product_id: '801',
                 top_level_attribute: "an_attribute",
-                type: 'configurable',
-                simple_product_ids: ['800', '801', '802'],
+                type: 'simple',
+                parent_id: '12345',
               },
             ]
 

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -43,57 +43,106 @@ module ShopifyTransporter
             expect(exporter.export).to eq(expected_result)
           end
 
-          it 'retrieves simple products from Magento using the SOAP API and injects parent_id' do
-            soap_client = double("soap client")
-            product_mapping_exporter = double("product_mapping_exporter")
+          context '#parent_id' do
+            let(:soap_client) { double("soap client") }
+            let(:product_mapping_exporter) { double("product_mapping_exporter") }
 
-            catalog_product_list_response_body = double('catalog_product_list_response_body')
-            catalog_product_info_response_body = double('catalog_product_info_response_body')
+            let(:catalog_product_list_response_body) { double('catalog_product_list_response_body') }
+            let(:catalog_product_info_response_body) { double('catalog_product_info_response_body') }
 
-            expect(soap_client)
-              .to receive(:call).with(:catalog_product_list, anything)
-              .and_return(catalog_product_list_response_body)
-              .at_least(:once)
+            it 'retrieves simple products from Magento using the SOAP API and injects parent_id' do
+              expect(soap_client)
+                .to receive(:call).with(:catalog_product_list, anything)
+                .and_return(catalog_product_list_response_body)
+                .at_least(:once)
 
-            expect(ProductMappingExporter).to receive(:new).and_return(product_mapping_exporter)
-            expect(product_mapping_exporter).to receive(:write_mappings)
+              expect(ProductMappingExporter).to receive(:new).and_return(product_mapping_exporter)
+              expect(product_mapping_exporter).to receive(:write_mappings)
 
-            expect(catalog_product_list_response_body).to receive(:body).and_return(
-              catalog_product_list_response: {
-                store_view: {
-                  item: [
-                    {
-                      product_id: '801',
-                      type: 'simple',
-                      top_level_attribute: "an_attribute",
-                    },
-                  ],
+              expect(catalog_product_list_response_body).to receive(:body).and_return(
+                catalog_product_list_response: {
+                  store_view: {
+                    item: [
+                      {
+                        product_id: '801',
+                        type: 'simple',
+                        top_level_attribute: "an_attribute",
+                      },
+                    ],
+                  },
                 },
-              },
-            ).at_least(:once)
+              ).at_least(:once)
 
-            expected_result = [
-              {
-                product_id: '801',
-                top_level_attribute: "an_attribute",
-                type: 'simple',
-                parent_id: '12345',
-              },
-            ]
+              expected_result = [
+                {
+                  product_id: '801',
+                  top_level_attribute: "an_attribute",
+                  type: 'simple',
+                  parent_id: '12345',
+                },
+              ]
 
-            mappings = <<~EOS
-              product_id,associated_product_id
-              12345,800
-              12345,801
-              12345,802
-              67890,900
-              67890,901
-            EOS
+              mappings = <<~EOS
+                product_id,associated_product_id
+                12345,800
+                12345,801
+                12345,802
+                67890,900
+                67890,901
+              EOS
 
-            in_temp_folder do
-              File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
-              exporter = described_class.new(store_id: 1, soap_client: soap_client, database_adapter: nil)
-              expect(exporter.export).to eq(expected_result)
+              in_temp_folder do
+                File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
+                exporter = described_class.new(store_id: 1, soap_client: soap_client, database_adapter: nil)
+                expect(exporter.export).to eq(expected_result)
+              end
+            end
+
+            it 'retrieves simple products from Magento and does not inject parent_id if the parent_id does not exist' do
+              expect(soap_client)
+                .to receive(:call).with(:catalog_product_list, anything)
+                .and_return(catalog_product_list_response_body)
+                .at_least(:once)
+
+              expect(ProductMappingExporter).to receive(:new).and_return(product_mapping_exporter)
+              expect(product_mapping_exporter).to receive(:write_mappings)
+
+              expect(catalog_product_list_response_body).to receive(:body).and_return(
+                catalog_product_list_response: {
+                  store_view: {
+                    item: [
+                      {
+                        product_id: '801',
+                        type: 'simple',
+                        top_level_attribute: "an_attribute",
+                      },
+                    ],
+                  },
+                },
+              ).at_least(:once)
+
+              expected_result = [
+                {
+                  product_id: '801',
+                  top_level_attribute: "an_attribute",
+                  type: 'simple',
+                },
+              ]
+
+              mappings = <<~EOS
+                product_id,associated_product_id
+                ,800
+                ,801
+                ,802
+                67890,900
+                67890,901
+              EOS
+
+              in_temp_folder do
+                File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
+                exporter = described_class.new(store_id: 1, soap_client: soap_client, database_adapter: nil)
+                expect(exporter.export).to eq(expected_result)
+              end
             end
           end
         end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -39,7 +39,7 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, client: soap_client)
+            exporter = described_class.new(store_id: 1, soap: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
 
@@ -88,7 +88,7 @@ module ShopifyTransporter
 
             in_temp_folder do
               File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
-              exporter = described_class.new(store_id: 1, client: soap_client)
+              exporter = described_class.new(store_id: 1, soap_client: soap_client)
               expect(exporter.export).to eq(expected_result)
             end
           end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -39,12 +39,13 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, soap: soap_client)
+            exporter = described_class.new(store_id: 1, soap_client: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
 
           it 'retrieves configurable products from Magento using the SOAP API and injects simple product ids' do
             soap_client = double("soap client")
+            product_mapping_exporter = double("product_mapping_exporter")
 
             catalog_product_list_response_body = double('catalog_product_list_response_body')
             catalog_product_info_response_body = double('catalog_product_info_response_body')
@@ -53,6 +54,9 @@ module ShopifyTransporter
               .to receive(:call).with(:catalog_product_list, anything)
               .and_return(catalog_product_list_response_body)
               .at_least(:once)
+
+            expect(ProductMappingExporter).to receive(:new).and_return(product_mapping_exporter)
+            expect(product_mapping_exporter).to receive(:write_mappings)
 
             expect(catalog_product_list_response_body).to receive(:body).and_return(
               catalog_product_list_response: {
@@ -88,7 +92,7 @@ module ShopifyTransporter
 
             in_temp_folder do
               File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
-              exporter = described_class.new(store_id: 1, soap_client: soap_client)
+              exporter = described_class.new(store_id: 1, soap_client: soap_client, database_adapter: nil)
               expect(exporter.export).to eq(expected_result)
             end
           end

--- a/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
@@ -12,19 +12,6 @@ module ShopifyTransporter
           end
         end
 
-        describe '#initialize' do
-          it 'initializes when provided the right values' do
-            described_class.new(
-              database: 'test',
-              host: '127.0.0.1',
-              port: 3306,
-              user: 'dbuser',
-              password: 'dbuserpassword',
-              filename: @tempfile.path
-            )
-          end
-        end
-
         describe '#extract_mappings' do
           it 'creates a new file' do
             expect(Sequel).to receive(:connect)

--- a/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_mapping_exporter_spec.rb
@@ -97,7 +97,7 @@ module ShopifyTransporter
                 mappings[2..3]
               )
 
-              subject.write_mappings('unused_file_name.ext')
+              subject.write_mappings(@tempfile.path)
             end
 
             it 'writes product mappings to the external file specified' do

--- a/spec/shopify_transporter/exporters/magento/sql_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/sql_spec.rb
@@ -24,7 +24,7 @@ module ShopifyTransporter
               password: 'some_password'
             )
 
-            sql_client.connect
+            sql_client.connect { |db| nil }
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/sql_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/sql_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'sequel'
+
+module ShopifyTransporter
+  module Exporters
+    module Magento
+      RSpec.describe SQL do
+        context ('#connect') do
+          it 'calls Sequel with the right parameters' do
+            sql_client = SQL.new(
+              database: 'magento',
+              hostname: 'magento-instance.domain.com',
+              port: 1234,
+              username: 'dbuser',
+              password: 'some_password'
+            )
+
+            expect(Sequel).to receive(:connect).with(
+              adapter: :mysql2,
+              database: 'magento',
+              host: 'magento-instance.domain.com',
+              port: 1234,
+              user: 'dbuser',
+              password: 'some_password'
+            )
+
+            sql_client.connect
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What it does and why:

Reads from the database and injects information about child products to each configurable product.

introduces the concept of a `database_adapter` which, like the `soap client`, allows classes later in the export pipeline to not have to know any configuration details

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:

https://github.com/Shopify/transporter_app/issues/1288