### PR TITLE
Fix the format of exported addresses

### DIFF
--- a/lib/shopify_transporter/exporters/magento/customer_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/customer_exporter.rb
@@ -25,7 +25,7 @@ module ShopifyTransporter
         end
 
         def customer_address_list(customer_id)
-          @client.call(:customer_address_list, customer_id: customer_id).body[:customer_address_list_response][:result]
+          @client.call(:customer_address_list, customer_id: customer_id).body
         end
 
         def filters

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -27,7 +27,7 @@ module ShopifyTransporter
         def info_for(order_increment_id)
           @client
             .call(:sales_order_info, order_increment_id: order_increment_id)
-            .body[:sales_order_info_response][:result]
+            .body[:sales_order_info_response]
         end
 
         def filters

--- a/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
@@ -37,7 +37,9 @@ module ShopifyTransporter
             expect(customer_address_list_response_body).to receive(:body).and_return(
               customer_address_list_response: {
                 result: {
-                  customer_address_attribute: "another_attribute",
+                  item: {
+                    customer_address_attribute: "another_attribute",
+                  }
                 },
               },
             ).at_least(:once)
@@ -47,7 +49,13 @@ module ShopifyTransporter
                 customer_id: 654321,
                 top_level_attribute: "an_attribute",
                 address_list: {
-                  customer_address_attribute: "another_attribute",
+                  customer_address_list_response: {
+                    result: {
+                      item: {
+                        customer_address_attribute: "another_attribute",
+                      }
+                    }
+                  },
                 },
               },
             ]

--- a/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
@@ -48,7 +48,9 @@ module ShopifyTransporter
                 increment_id: 12345,
                 top_level_attribute: "an_attribute",
                 items: {
-                  order_info_attribute: "another_attribute",
+                  result: {
+                    order_info_attribute: "another_attribute",
+                  }
                 },
               },
             ]


### PR DESCRIPTION
### What it does and why:
- Makes the format of the exports match the expected format of the converter tool.

### Checklist:

- [X] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/27
