### PR TITLE
Remove filters from order and customer soap calls to retrieve all data

### DIFF
--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -21,7 +21,6 @@ module ShopifyTransporter
         data = Magento::MagentoExporter
           .for(type: object_type)
           .new(
-            store_id: config['export_configuration']['store_id'],
             soap_client: soap_client,
             database_adapter: database_adapter
           )
@@ -65,7 +64,6 @@ module ShopifyTransporter
           %w(export_configuration soap hostname),
           %w(export_configuration soap username),
           %w(export_configuration soap api_key),
-          %w(export_configuration store_id),
         ]
 
         product_required_keys = [

--- a/lib/shopify_transporter/exporters/magento/customer_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/customer_exporter.rb
@@ -4,9 +4,8 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class CustomerExporter
-        def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
+        def initialize(soap_client: nil, database_adapter: nil)
           @client = soap_client
-          @store_id = store_id
           @database_adapter = database_adapter
         end
 
@@ -21,23 +20,12 @@ module ShopifyTransporter
         private
 
         def base_customers
-          result = @client.call(:customer_customer_list, filters: filters).body
+          result = @client.call(:customer_customer_list, filters: nil).body
           result[:customer_customer_list_response][:store_view][:item] || []
         end
 
         def customer_address_list(customer_id)
           @client.call(:customer_address_list, customer_id: customer_id).body
-        end
-
-        def filters
-          {
-            filter: {
-              item: {
-                key: 'store_id',
-                value: @store_id,
-              },
-            },
-          }
         end
       end
     end

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -4,9 +4,8 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class OrderExporter
-        def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
+        def initialize(soap_client: nil, database_adapter: nil)
           @client = soap_client
-          @store_id = store_id
           @database_adapter = database_adapter
         end
 
@@ -21,7 +20,7 @@ module ShopifyTransporter
         private
 
         def base_orders
-          result = @client.call(:sales_order_list, filters: filters).body
+          result = @client.call(:sales_order_list, filters: nil).body
           result[:sales_order_list_response][:result][:item] || []
         end
 
@@ -29,17 +28,6 @@ module ShopifyTransporter
           @client
             .call(:sales_order_info, order_increment_id: order_increment_id)
             .body[:sales_order_info_response]
-        end
-
-        def filters
-          {
-            filter: {
-              item: {
-                key: 'store_id',
-                value: @store_id,
-              },
-            },
-          }
         end
       end
     end

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -6,8 +6,7 @@ module ShopifyTransporter
   module Exporters
     module Magento
       class ProductExporter
-        def initialize(store_id: nil, soap_client: nil, database_adapter: nil)
-          @store_id = store_id
+        def initialize(soap_client: nil, database_adapter: nil)
           @client = soap_client
           @database_adapter = database_adapter
           @intermediate_file_name = 'magento_product_mappings.csv'

--- a/lib/templates/magento/config.tt
+++ b/lib/templates/magento/config.tt
@@ -16,7 +16,7 @@ object_types:
             - group
             - free_trial_start_at
   product:
-    record_key: product_id 
+    record_key: product_id
     pipeline_stages:
       - TopLevelAttributes
       - VariantAttributes
@@ -39,4 +39,3 @@ export_configuration:
     user:
     password:
     database:
-  store_id:

--- a/spec/shopify_transporter/exporters/exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/exporter_spec.rb
@@ -42,7 +42,6 @@ module ShopifyTransporter
               "user" => 'something',
               "password" => 'a_password',
             },
-            "store_id" => 1,
           },
         }
       end
@@ -92,16 +91,6 @@ module ShopifyTransporter
         config_file = tmpfile(YAML.dump(config_without_export_configuration), '.yml')
 
         error_message = "Invalid configuration: missing required key 'export_configuration'"
-
-        expect { Exporter.new(config_file.path, :unused) }
-          .to raise_error(InvalidConfigError, error_message)
-      end
-
-      it 'raises InvalidConfigError if config file is missing store id' do
-        config = default_config.tap { |cfg| cfg['export_configuration'].delete('store_id') }
-        config_file = tmpfile(YAML.dump(config), '.yml')
-
-        error_message = "Invalid configuration: missing required key 'export_configuration > store_id'"
 
         expect { Exporter.new(config_file.path, :unused) }
           .to raise_error(InvalidConfigError, error_message)

--- a/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
@@ -60,7 +60,7 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, soap_client: soap_client)
+            exporter = described_class.new(soap_client: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
         end

--- a/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
@@ -55,7 +55,7 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, soap_client: soap_client)
+            exporter = described_class.new(soap_client: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
         end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -108,7 +108,7 @@ module ShopifyTransporter
               },
             ]
 
-            exporter = described_class.new(store_id: 1, soap_client: soap_client)
+            exporter = described_class.new(soap_client: soap_client)
             expect(exporter.export).to eq(expected_result)
           end
 
@@ -249,7 +249,7 @@ module ShopifyTransporter
 
               in_temp_folder do
                 File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
-                exporter = described_class.new(store_id: 1, soap_client: soap_client, database_adapter: nil)
+                exporter = described_class.new(soap_client: soap_client, database_adapter: nil)
                 expect(exporter.export).to eq(expected_result)
               end
             end
@@ -328,7 +328,7 @@ module ShopifyTransporter
                     ]
                   }
                 })
-                
+
               expect(soap_client)
                 .to receive(:call).with(:catalog_inventory_stock_item_list, {:products=>{:product_id=>"801"}})
                 .and_return(catalog_inventory_stock_item_list_response_body)
@@ -377,7 +377,7 @@ module ShopifyTransporter
 
               in_temp_folder do
                 File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
-                exporter = described_class.new(store_id: 1, soap_client: soap_client, database_adapter: nil)
+                exporter = described_class.new(soap_client: soap_client, database_adapter: nil)
                 expect(exporter.export).to eq(expected_result)
               end
             end


### PR DESCRIPTION
### What it does and why:
- Removes the `store_id` filter for orders and customers, because this limits the data returned.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.

---

### Related issues: https://github.com/Shopify/shopify_transporter/issues/28
