### PR TITLE
Update Installation docs to include requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When filing an issue, please ensure that:
 
 ### Requirements:
 1. A Ruby version of 2.4.0 or higher
-2. You are able to install Ruby gems. Please visit [the Bundler website](https://bundler.io/) to troubleshoot issues with installing gems
+2. You are able to install Ruby gems. Please visit [the Bundler website](https://bundler.io/) to troubleshoot issues with installing gems.
 
 We test and support the gem for Mac OS environments. The gem might work fine on other operations systems provided you meet the above requirements, but they are not officially supported.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ When filing an issue, please ensure that:
 
 ## Installation
 
+### Requirements:
+1. A Ruby version of 2.4.0 or higher
+2. You are able to install Ruby gems. Please visit [the Bundler website](https://bundler.io/) to troubleshoot issues with installing gems
+
+We test and support the gem for Mac OS environments. The gem might work fine on other operations systems provided you meet the above requirements, but they are not officially supported.
+
 ### Installing the Transporter tool gem from rubygems:
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When filing an issue, please ensure that:
 1. A Ruby version of 2.4.0 or higher
 2. You are able to install Ruby gems. Please visit [the Bundler website](https://bundler.io/) to troubleshoot issues with installing gems.
 
-We test and support the gem for Mac OS environments. The gem might work fine on other operations systems provided you meet the above requirements, but they are not officially supported.
+We test and support the gem for Mac OS environments. While not officially supported, the gem may work on other operating systems provided they meet the above requirements.
 
 ### Installing the Transporter tool gem from rubygems:
 


### PR DESCRIPTION
### What it does and why:
- Update Installation docs to include installation requirements because they are not clear.

### Checklist:

- [X] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/16
