### PR TITLE
Disconnect database properly after yielding

### DIFF
--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -30,6 +30,7 @@ module ShopifyTransporter
             database: @database
           )
           yield(@connection)
+        ensure
           @connection.disconnect
         end
       end

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -30,6 +30,7 @@ module ShopifyTransporter
             database: @database
           )
           yield(@connection)
+          @connection.disconnect
         end
       end
     end

--- a/lib/shopify_transporter/exporters/magento/sql.rb
+++ b/lib/shopify_transporter/exporters/magento/sql.rb
@@ -21,17 +21,16 @@ module ShopifyTransporter
         end
 
         def connect
-          @connection ||= Sequel.connect(
+          Sequel.connect(
             adapter: :mysql2,
             user: @user,
             password: @password,
             host: @host,
             port: @port,
             database: @database
-          )
-          yield(@connection)
-        ensure
-          @connection.disconnect
+          ) do |connection|
+            yield connection
+          end
         end
       end
     end

--- a/spec/files/config-with-all-platforms-stage-type.yml
+++ b/spec/files/config-with-all-platforms-stage-type.yml
@@ -1,0 +1,8 @@
+platform_type: Magento
+object_types:
+  customer:
+    record_key: email
+    key_required: true
+    pipeline_stages:
+      - TopLevelAttributes:
+        type: all_platforms

--- a/spec/shopify_transporter/exporters/magento/sql_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/sql_spec.rb
@@ -28,12 +28,13 @@ module ShopifyTransporter
               user: 'dbuser',
               password: 'some_password'
             ).and_return(connection)
-            expect(connection).to receive(:disconnect)
 
             sql_client.connect { |db| nil }
           end
 
-          it 'disconnects the database even if the given block raises an error' do
+          it 'yields the db connection on SQL#connect' do
+            connection = double('db connection')
+
             expect(Sequel).to receive(:connect).with(
               adapter: :mysql2,
               database: 'magento',
@@ -41,12 +42,9 @@ module ShopifyTransporter
               port: 1234,
               user: 'dbuser',
               password: 'some_password'
-            ).and_return(connection)
-            expect(connection).to receive(:disconnect)
+            ).and_yield(connection)
 
-            expect do
-              sql_client.connect { |db| raise('database lost connection!') }
-            end.to raise_error('database lost connection!')
+            sql_client.connect { |db| expect(db).to eq(connection) }
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/sql_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/sql_spec.rb
@@ -6,17 +6,20 @@ module ShopifyTransporter
     module Magento
       RSpec.describe SQL do
         context ('#connect') do
-          it 'calls Sequel with the right parameters' do
-            sql_client = SQL.new(
+
+          let(:sql_client) do
+            SQL.new(
               database: 'magento',
               host: 'magento-instance.domain.com',
               port: 1234,
               user: 'dbuser',
               password: 'some_password'
             )
+          end
 
-            connection = double('connection')
+          let(:connection) { double('connection') }
 
+          it 'calls Sequel with the right parameters' do
             expect(Sequel).to receive(:connect).with(
               adapter: :mysql2,
               database: 'magento',
@@ -25,10 +28,25 @@ module ShopifyTransporter
               user: 'dbuser',
               password: 'some_password'
             ).and_return(connection)
-
             expect(connection).to receive(:disconnect)
 
             sql_client.connect { |db| nil }
+          end
+
+          it 'disconnects the database even if the given block raises an error' do
+            expect(Sequel).to receive(:connect).with(
+              adapter: :mysql2,
+              database: 'magento',
+              host: 'magento-instance.domain.com',
+              port: 1234,
+              user: 'dbuser',
+              password: 'some_password'
+            ).and_return(connection)
+            expect(connection).to receive(:disconnect)
+
+            expect do
+              sql_client.connect { |db| raise('database lost connection!') }
+            end.to raise_error('database lost connection!')
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/sql_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/sql_spec.rb
@@ -15,6 +15,8 @@ module ShopifyTransporter
               password: 'some_password'
             )
 
+            connection = double('connection')
+
             expect(Sequel).to receive(:connect).with(
               adapter: :mysql2,
               database: 'magento',
@@ -22,7 +24,9 @@ module ShopifyTransporter
               port: 1234,
               user: 'dbuser',
               password: 'some_password'
-            )
+            ).and_return(connection)
+
+            expect(connection).to receive(:disconnect)
 
             sql_client.connect { |db| nil }
           end

--- a/spec/shopify_transporter/shopify_transporter_spec.rb
+++ b/spec/shopify_transporter/shopify_transporter_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe ShopifyTransporter do
       )
     end
 
+    it 'runs a pipeline for all_platforms' do
+      files = ['spec/files/blank.csv']
+      config = 'spec/files/config-with-all-platforms-stage-type.yml'
+      mock_stage_class = double("mock_stage_class")
+
+      allow(Object).to receive(:const_get).with('ShopifyTransporter::Shopify::Customer')
+      expect(Object).to receive(:const_get).once.with('ShopifyTransporter::Pipeline::AllPlatforms::TopLevelAttributes').and_return(mock_stage_class)
+
+      expect { TransporterTool.new(*files, config, 'customer') }.to raise_error(TransporterTool::StageNotFoundError)
+    end
+
     it 'looks in the default namespace for namespaces that are specified as strings' do
       files = ['spec/files/blank.csv']
       config = 'spec/files/config.yml'


### PR DESCRIPTION
### What it does and why:

Makes sure to disconnect from the database after the given block is run. This may be the reason we were encountering weird unpredictable behaviour with database connection limits last week.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
