### PR TITLE
handle extracting product top level info

### DIFF
--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module ShopifyTransporter
   module Exporters
     module Magento
@@ -11,7 +10,10 @@ module ShopifyTransporter
 
         def export
           $stderr.puts 'Starting export...'
-          base_products.compact
+          base_products.map do |product|
+            $stderr.puts "Fetching products: #{product[:product_id]}"
+            product.merge(items: info_for(product[:product_id]))
+          end.compact
         end
 
         private
@@ -19,6 +21,12 @@ module ShopifyTransporter
         def base_products
           result = @client.call(:catalog_product_list, filters: nil).body
           result[:catalog_product_list_response][:store_view][:item] || []
+        end
+
+        def info_for(product_id)
+          @client
+            .call(:catalog_product_info, product_id: product_id)
+            .body
         end
       end
     end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -30,10 +30,26 @@ module ShopifyTransporter
               },
             ).at_least(:once)
 
+            expect(soap_client)
+              .to receive(:call).with(:catalog_product_info, product_id: 12345)
+              .and_return(catalog_product_info_response_body)
+              .at_least(:once)
+
+            expect(catalog_product_info_response_body).to receive(:body).and_return(
+              catalog_product_info_response: {
+                  info: "another_attribute",
+              }
+            ).at_least(:once)
+
             expected_result = [
               {
                 product_id: 12345,
                 top_level_attribute: "an_attribute",
+                items: {
+                  catalog_product_info_response: {
+                    info: "another_attribute"
+                  }
+                }
               },
             ]
 


### PR DESCRIPTION
### What it does and why: 
Add support to extract product top-level information by calling the Magento SOAP API. Related test has been updated.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues: N/A
Closes: N/A
