### PR TITLE
Require all database fields and make key missing error clearer

### DIFF
--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -70,14 +70,16 @@ module ShopifyTransporter
 
         product_required_keys = [
           %w(export_configuration database host),
-          %w(export_configuration database user),
+          %w(export_configuration database port),
           %w(export_configuration database database),
+          %w(export_configuration database user),
+          %w(export_configuration database password),
         ]
 
         required_keys = base_required_keys + (@object_type == 'product' ? product_required_keys : [])
 
         required_keys.each do |keys|
-          raise InvalidConfigError, "missing required key '#{keys.last}'" unless config.dig(*keys)
+          raise InvalidConfigError, "missing required key '#{keys.join(' > ')}'" unless config.dig(*keys)
         end
       end
     end


### PR DESCRIPTION
### What it does and why:
- Requires all database connection keys.
- Makes the error message for missing keys more descriptive to be able to locate the right keys.

### Checklist:
- [X] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.