### PR TITLE
Implement capability to extract and convert variant inventory quantity

### DIFF
--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -17,7 +17,7 @@ module ShopifyTransporter
           $stderr.puts 'Starting export...'
           products = base_products.map do |product|
             $stderr.puts "Fetching product: #{product[:product_id]}"
-            populate_product_info(product)
+            with_attributes(product)
           end.compact
           apply_mappings(products)
         end
@@ -60,16 +60,16 @@ module ShopifyTransporter
           product.merge(parent_id: product_mappings[product[:product_id]])
         end
 
-        def populate_product_info(product)
-          product_with_base_info = product
+        def with_attributes(product)
+          product_with_base_attributes = product
             .merge(images: images_attribute(product[:product_id]))
             .merge(info_for(product[:product_id]))
 
           case product[:type]
           when 'simple'
-            product_with_base_info.merge(inventory_quantity: inventory_quantity_for(product[:product_id]))
+            product_with_base_attributes.merge(inventory_quantity: inventory_quantity_for(product[:product_id]))
           else
-            product_with_base_info
+            product_with_base_attributes
           end
         end
 

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
@@ -20,6 +20,7 @@ module ShopifyTransporter
               'sku' => 'sku',
               'weight' => 'grams',
               'price' => 'price',
+              'inventory_quantity' => 'inventory_qty',
             }
             def input_applies?(input)
               true unless input['parent_id'].nil?

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -75,7 +75,7 @@ FactoryBot.define do
     sequence(:created_at) { '2013-03-05T01:25:10-05:00' }
     sequence(:published_scope) { 'web' }
     sequence(:parent_id) { '1' }
-    
+
     initialize_with { attributes.deep_stringify_keys }
   end
 
@@ -98,6 +98,7 @@ FactoryBot.define do
     sequence(:title) { 'French Cuff Cotton Twill Oxford' }
     sequence(:body_html) { 'Button front. Long sleeves. Tapered collar, chest pocket, french cuffs.' }
     sequence(:handle) { 'french-cuff-cotton-twill-oxford' }
+    sequence(:inventory_quantity) { |n| n }
     sequence(:parent_id) { '3' }
     sequence(:price) { '222' }
     sequence(:weight) { '100' }
@@ -106,4 +107,3 @@ FactoryBot.define do
     initialize_with { attributes.deep_stringify_keys }
   end
 end
-

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -82,6 +82,7 @@ module ShopifyTransporter
 
             let(:catalog_product_list_response_body) { double('catalog_product_list_response_body') }
             let(:catalog_product_info_response_body) { double('catalog_product_info_response_body') }
+            let(:catalog_inventory_stock_item_list_response_body) { double('catalog_inventory_stock_item_list_response_body') }
             let(:catalog_product_attribute_media_list_response_body) do
               double('catalog_product_attribute_media_list_response_body')
             end
@@ -122,6 +123,20 @@ module ShopifyTransporter
               ).at_least(:once)
 
               expect(soap_client)
+                .to receive(:call).with(:catalog_inventory_stock_item_list, {:products=>{:product_id=>"801"}})
+                .and_return(catalog_inventory_stock_item_list_response_body)
+
+              expect(catalog_inventory_stock_item_list_response_body).to receive(:body).and_return(
+                catalog_inventory_stock_item_list_response: {
+                  result: {
+                    item: {
+                      qty: 5
+                    }
+                  }
+                }
+              )
+
+              expect(soap_client)
                 .to receive(:call).with(:catalog_product_attribute_media_list, product: 801)
                 .and_return(catalog_product_attribute_media_list_response_body)
 
@@ -146,6 +161,7 @@ module ShopifyTransporter
                   top_level_attribute: "an_attribute",
                   type: 'simple',
                   parent_id: '12345',
+                  inventory_quantity: 5,
                   attribute_key: "another_attribute",
                   images: [{ url: :img_src }, { url: :img_src2 }]
                 },
@@ -220,11 +236,26 @@ module ShopifyTransporter
                 }
               )
 
+              expect(soap_client)
+                .to receive(:call).with(:catalog_inventory_stock_item_list, {:products=>{:product_id=>"801"}})
+                .and_return(catalog_inventory_stock_item_list_response_body)
+
+              expect(catalog_inventory_stock_item_list_response_body).to receive(:body).and_return(
+                catalog_inventory_stock_item_list_response: {
+                  result: {
+                    item: {
+                      qty: 5
+                    }
+                  }
+                }
+              )
+
               expected_result = [
                 {
                   product_id: '801',
                   type: 'simple',
                   top_level_attribute: "an_attribute",
+                  inventory_quantity: 5,
                   another_key: "another_attribute",
                   images: [{ url: :img_src }, { url: :img_src2 }]
                 },

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -12,7 +12,8 @@ module ShopifyTransporter::Pipeline::Magento::Product
         expected_variants_in_shopify_format = {
           sku: child_product['sku'],
           grams: child_product['weight'],
-          price: child_product['price']
+          price: child_product['price'],
+          inventory_qty: child_product['inventory_quantity'],
         }
 
         expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
@@ -30,7 +31,8 @@ module ShopifyTransporter::Pipeline::Magento::Product
         expected_variants_in_shopify_format = {
           sku: child_product['sku'],
           grams: child_product['weight'],
-          price: child_product['price']
+          price: child_product['price'],
+          inventory_qty: child_product['inventory_quantity'],
         }
 
         expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
@@ -45,7 +47,8 @@ module ShopifyTransporter::Pipeline::Magento::Product
           product_id: child_product['product_id'],
           sku: child_product['sku'],
           grams: child_product['weight'],
-          price: child_product['price']
+          price: child_product['price'],
+          inventory_qty: child_product['inventory_quantity'],
         }
 
         expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)


### PR DESCRIPTION
### What it does and why:

Pulls the inventory quantity from the SOAP API, then converts it to Shopify's format inside the variant.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
https://github.com/Shopify/transporter_app/issues/1327