### PR TITLE
Extract and convert product tags

### DIFF
--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -20,6 +20,7 @@ module ShopifyTransporter
             product
               .merge(images: images_attribute(product[:product_id]))
               .merge(info_for(product[:product_id]))
+              .merge(tags: product_tags(product[:product_id]))
           end.compact
           apply_mappings(products)
         end
@@ -72,6 +73,12 @@ module ShopifyTransporter
           @client
             .call(:catalog_product_attribute_media_list, product: product_id.to_i)
             .body[:catalog_product_attribute_media_list_response][:result][:item]
+        end
+
+        def product_tags(product_id)
+          @client
+            .call(:catalog_product_tag_list, product_id: product_id.to_i)
+            .body[:catalog_product_tag_list_response][:result][:item]
         end
       end
     end

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -31,6 +31,7 @@ module ShopifyTransporter
               attributes['published_scope'] = published?(input) ? 'global' : ''
               attributes['published_at'] = published?(input) ? input['updated_at'] : ''
               attributes['images'] = append_images(input) if input['images'].present?
+              attributes['tags'] = product_tags(input) if input['tags'].present?
               attributes
             end
 
@@ -53,6 +54,12 @@ module ShopifyTransporter
               if label.is_a? String
                 label
               end
+            end
+
+            def product_tags(input)
+              input['tags'].each_with_object([]) do |tag, array|
+                array << tag['name']
+              end.join(', ')
             end
           end
         end

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -57,9 +57,7 @@ module ShopifyTransporter
             end
 
             def product_tags(input)
-              input['tags'].each_with_object([]) do |tag, array|
-                array << tag['name']
-              end.join(', ')
+              input['tags'].map { |tag| tag['name'] }.join(', ')
             end
           end
         end

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
@@ -8,6 +8,7 @@ module ShopifyTransporter
       module Product
         class TopLevelVariantAttributes < Pipeline::Stage
           def convert(hash, record)
+            return if record['variants'].nil?
             simple_product_in_magento_format = record['variants'].select do |product|
               product['product_id'] == hash['product_id']
             end.first

--- a/lib/shopify_transporter/record_builder/product_record_builder.rb
+++ b/lib/shopify_transporter/record_builder/product_record_builder.rb
@@ -26,6 +26,7 @@ module ShopifyTransporter
     def parent_record(product)
       parent_id = product['parent_id']
       record = @instances[parent_id] ||= {}
+      record['variants'] ||= []
       @last_record = record
     end
   end

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -36,6 +36,23 @@ FactoryBot.define do
       end
     end
 
+    trait :with_product_tags do
+      tags do
+        [
+          {
+            "tag_id": "17",
+            "name": "white",
+            "@xsi:type": "ns1:catalogProductTagListEntity"
+          },
+          {
+            "tag_id": "18",
+            "name": "shirt",
+            "@xsi:type": "ns1:catalogProductTagListEntity"
+          }
+        ]
+      end
+    end
+
     initialize_with { attributes.deep_stringify_keys }
   end
 

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -326,6 +326,8 @@ module ShopifyTransporter
                         "@xsi:type": "ns1:catalogProductTagListEntity"
                       }
                     ]
+                  }
+                })
                 
               expect(soap_client)
                 .to receive(:call).with(:catalog_inventory_stock_item_list, {:products=>{:product_id=>"801"}})

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
-require 'pry'
+
 module ShopifyTransporter
   module Exporters
     module Magento

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
-
+require 'pry'
 module ShopifyTransporter
   module Exporters
     module Magento
@@ -12,6 +12,7 @@ module ShopifyTransporter
             catalog_product_list_response_body = double('catalog_product_list_response_body')
             catalog_product_info_response_body = double('catalog_product_info_response_body')
             catalog_product_attribute_media_list_response_body = double('catalog_product_attribute_media_list_response_body')
+            catalog_product_tag_list_response_body = double('catalog_product_tag_list_response_body')
 
             expect(soap_client)
               .to receive(:call).with(:catalog_product_list, anything)
@@ -62,13 +63,48 @@ module ShopifyTransporter
               }
             )
 
+            expect(soap_client)
+              .to receive(:call).with(:catalog_product_tag_list, product_id: 12345)
+                    .and_return(catalog_product_tag_list_response_body)
+
+            expect(catalog_product_tag_list_response_body).to receive(:body).and_return(
+              catalog_product_tag_list_response: {
+                result: {
+                  item: [
+                    {
+                      "tag_id": "17",
+                      "name": "white",
+                      "@xsi:type": "ns1:catalogProductTagListEntity"
+                    },
+                    {
+                      "tag_id": "18",
+                      "name": "shirt",
+                      "@xsi:type": "ns1:catalogProductTagListEntity"
+                    }
+                  ]
+                }
+              }
+            )
+
             expected_result = [
               {
                 product_id: '12345',
                 type: 'configurable',
                 top_level_attribute: "an_attribute",
                 attribute_key: "another_attribute",
-                images: [{ url: :img_src }, { url: :img_src2 }]
+                images: [{ url: :img_src }, { url: :img_src2 }],
+                tags: [
+                  {
+                    "tag_id": "17",
+                    "name": "white",
+                    "@xsi:type": "ns1:catalogProductTagListEntity"
+                  },
+                  {
+                    "tag_id": "18",
+                    "name": "shirt",
+                    "@xsi:type": "ns1:catalogProductTagListEntity"
+                  }
+                ]
               },
             ]
 
@@ -85,6 +121,7 @@ module ShopifyTransporter
             let(:catalog_product_attribute_media_list_response_body) do
               double('catalog_product_attribute_media_list_response_body')
             end
+            let(:catalog_product_tag_list_response_body) { double('catalog_product_tag_list_response_body') }
 
             it 'retrieves simple products from Magento using the SOAP API and injects parent_id' do
               expect(soap_client)
@@ -140,6 +177,28 @@ module ShopifyTransporter
                 }
               )
 
+              expect(soap_client)
+                .to receive(:call).with(:catalog_product_tag_list, product_id: 801)
+                      .and_return(catalog_product_tag_list_response_body)
+
+              expect(catalog_product_tag_list_response_body).to receive(:body).and_return(
+                catalog_product_tag_list_response: {
+                  result: {
+                    item: [
+                      {
+                        "tag_id": "17",
+                        "name": "white",
+                        "@xsi:type": "ns1:catalogProductTagListEntity"
+                      },
+                      {
+                        "tag_id": "18",
+                        "name": "shirt",
+                        "@xsi:type": "ns1:catalogProductTagListEntity"
+                      }
+                    ]
+                  }
+                }
+              )
               expected_result = [
                 {
                   product_id: '801',
@@ -147,7 +206,19 @@ module ShopifyTransporter
                   type: 'simple',
                   parent_id: '12345',
                   attribute_key: "another_attribute",
-                  images: [{ url: :img_src }, { url: :img_src2 }]
+                  images: [{ url: :img_src }, { url: :img_src2 }],
+                  tags: [
+                    {
+                      "tag_id": "17",
+                      "name": "white",
+                      "@xsi:type": "ns1:catalogProductTagListEntity"
+                    },
+                    {
+                      "tag_id": "18",
+                      "name": "shirt",
+                      "@xsi:type": "ns1:catalogProductTagListEntity"
+                    }
+                  ]
                 },
               ]
 
@@ -220,13 +291,48 @@ module ShopifyTransporter
                 }
               )
 
+              expect(soap_client)
+                .to receive(:call).with(:catalog_product_tag_list, product_id: 801)
+                      .and_return(catalog_product_tag_list_response_body)
+
+              expect(catalog_product_tag_list_response_body).to receive(:body).and_return(
+                catalog_product_tag_list_response: {
+                  result: {
+                    item: [
+                      {
+                        "tag_id": "17",
+                        "name": "white",
+                        "@xsi:type": "ns1:catalogProductTagListEntity"
+                      },
+                      {
+                        "tag_id": "18",
+                        "name": "shirt",
+                        "@xsi:type": "ns1:catalogProductTagListEntity"
+                      }
+                    ]
+                  }
+                }
+              )
+
               expected_result = [
                 {
                   product_id: '801',
                   type: 'simple',
                   top_level_attribute: "an_attribute",
                   another_key: "another_attribute",
-                  images: [{ url: :img_src }, { url: :img_src2 }]
+                  images: [{ url: :img_src }, { url: :img_src2 }],
+                  tags: [
+                    {
+                      "tag_id": "17",
+                      "name": "white",
+                      "@xsi:type": "ns1:catalogProductTagListEntity"
+                    },
+                    {
+                      "tag_id": "18",
+                      "name": "shirt",
+                      "@xsi:type": "ns1:catalogProductTagListEntity"
+                    }
+                  ]
                 },
               ]
 

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -43,6 +43,15 @@ module ShopifyTransporter::Pipeline::Magento::Product
         expect(shopify_product.deep_stringify_keys).to_not include(with_nonsense.deep_stringify_keys)
       end
 
+      it 'should handle product tags conversion' do
+        magento_product = FactoryBot.build(:magento_product, :with_product_tags)
+        shopify_product = described_class.new.convert(magento_product, {})
+        expected_product_tag_info = {
+          tags: 'white, shirt'
+        }
+        expect(shopify_product.deep_stringify_keys).to include(expected_product_tag_info.deep_stringify_keys)
+      end
+
       context '#images' do
         it 'handles images with no labels' do
           magento_product = FactoryBot.build(:magento_product, :with_no_label_image)

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/top_level_variant_attributes'
-require 'pry'
+
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe TopLevelVariantAttributes, type: :helper do
     context '#convert' do

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/top_level_variant_attributes'
-
+require 'pry'
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe TopLevelVariantAttributes, type: :helper do
     context '#convert' do
@@ -52,6 +52,14 @@ module ShopifyTransporter::Pipeline::Magento::Product
         }
 
         expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+      end
+
+      it 'should skip converting top level variants when the input is a product without parent_id' do
+        simple_product_without_parent = FactoryBot.build(:simple_magento_product)
+        simple_product_without_parent.delete("parent_id")
+        binding.pry
+        variants_in_shopify_format = described_class.new.convert(simple_product_without_parent, {})
+        expect(variants_in_shopify_format).to be_nil
       end
     end
   end

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/top_level_variant_attributes'
-require 'pry'
+
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe TopLevelVariantAttributes, type: :helper do
     context '#convert' do
@@ -57,7 +57,6 @@ module ShopifyTransporter::Pipeline::Magento::Product
       it 'should skip converting top level variants when the input is a product without parent_id' do
         simple_product_without_parent = FactoryBot.build(:simple_magento_product)
         simple_product_without_parent.delete("parent_id")
-        binding.pry
         variants_in_shopify_format = described_class.new.convert(simple_product_without_parent, {})
         expect(variants_in_shopify_format).to be_nil
       end

--- a/spec/shopify_transporter/record_builder/product_record_builder_spec.rb
+++ b/spec/shopify_transporter/record_builder/product_record_builder_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe ShopifyTransporter::ProductRecordBuilder do
       end
     end
 
-    it "Should yield an empty record if the product has a parent id and its parent wasn't previously seen" do
+    it "Should yield an record with empry variants if the product has a parent id and its parent wasn't previously seen" do
       @builder.build({'product_id' => '3', 'parent_id' => '4'}) do |record|
-        expect(record).to eq({})
+        expect(record).to eq({"variants"=>[]})
         record['key2'] = 'val2'
       end
     end

--- a/spec/shopify_transporter/record_builder/product_record_builder_spec.rb
+++ b/spec/shopify_transporter/record_builder/product_record_builder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'shopify_transporter/record_builder/record_builder'
-require 'pry'
+
 RSpec.describe ShopifyTransporter::ProductRecordBuilder do
 
   before(:all) do


### PR DESCRIPTION
### What it does and why:
Extract and convert product tags

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

### Demo:
<img width="165" alt="screen shot 2018-09-26 at 11 12 12 am" src="https://user-images.githubusercontent.com/21313470/46089684-1019d000-c17d-11e8-9393-b6f3dce9ad89.png">

---

### Related issues: https://github.com/Shopify/transporter_app/issues/1321
Closes:
