### PR TITLE
Extract and convert variant images

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -30,8 +30,12 @@ module ShopifyTransporter
               attributes['published'] = published?(input)
               attributes['published_scope'] = published?(input) ? 'global' : ''
               attributes['published_at'] = published?(input) ? input['updated_at'] : ''
+<<<<<<< HEAD
               append_images_to_current_record!(input) if input['images'].present?
+=======
+>>>>>>> extract and convert variant images
               attributes['tags'] = product_tags(input) if input['tags'].present?
+              append_images(input) if input['images'].present?
               attributes
             end
 
@@ -50,7 +54,11 @@ module ShopifyTransporter
               images.sort_by { |image| image['position'] }
             end
 
+<<<<<<< HEAD
             def append_images_to_current_record!(input)
+=======
+            def append_images(input)
+>>>>>>> extract and convert variant images
               images = construct_images(input)
               if @output['images'].present?
                 @output['images'].concat(images)

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -30,8 +30,8 @@ module ShopifyTransporter
               attributes['published'] = published?(input)
               attributes['published_scope'] = published?(input) ? 'global' : ''
               attributes['published_at'] = published?(input) ? input['updated_at'] : ''
-              attributes['images'] = append_images(input) if input['images'].present?
               attributes['tags'] = product_tags(input) if input['tags'].present?
+              append_images(input) if input['images'].present?
               attributes
             end
 
@@ -39,7 +39,7 @@ module ShopifyTransporter
               input['visibility'].present? && input['visibility'].to_i != 1
             end
 
-            def append_images(input)
+            def construct_images(input)
               images = input['images'].map do |image|
                 {
                   'src' => image['url'],
@@ -48,6 +48,15 @@ module ShopifyTransporter
                 }.compact
               end
               images.sort_by { |image| image['position'] }
+            end
+
+            def append_images(input)
+              images = construct_images(input)
+              if @output['images'].present?
+                @output['images'].concat(images)
+              else
+                @output['images'] = images
+              end
             end
 
             def image_alt_text(label)

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -30,12 +30,8 @@ module ShopifyTransporter
               attributes['published'] = published?(input)
               attributes['published_scope'] = published?(input) ? 'global' : ''
               attributes['published_at'] = published?(input) ? input['updated_at'] : ''
-<<<<<<< HEAD
               append_images_to_current_record!(input) if input['images'].present?
-=======
->>>>>>> extract and convert variant images
               attributes['tags'] = product_tags(input) if input['tags'].present?
-              append_images(input) if input['images'].present?
               attributes
             end
 
@@ -54,11 +50,7 @@ module ShopifyTransporter
               images.sort_by { |image| image['position'] }
             end
 
-<<<<<<< HEAD
             def append_images_to_current_record!(input)
-=======
-            def append_images(input)
->>>>>>> extract and convert variant images
               images = construct_images(input)
               if @output['images'].present?
                 @output['images'].concat(images)

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -30,8 +30,8 @@ module ShopifyTransporter
               attributes['published'] = published?(input)
               attributes['published_scope'] = published?(input) ? 'global' : ''
               attributes['published_at'] = published?(input) ? input['updated_at'] : ''
+              append_images_to_current_record!(input) if input['images'].present?
               attributes['tags'] = product_tags(input) if input['tags'].present?
-              append_images(input) if input['images'].present?
               attributes
             end
 
@@ -50,7 +50,7 @@ module ShopifyTransporter
               images.sort_by { |image| image['position'] }
             end
 
-            def append_images(input)
+            def append_images_to_current_record!(input)
               images = construct_images(input)
               if @output['images'].present?
                 @output['images'].concat(images)

--- a/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
@@ -9,8 +9,8 @@ module ShopifyTransporter
         class VariantImage < Pipeline::Stage
           def convert(hash, record)
             return unless input_applied?(hash)
-            accumulate(hash, record)
-            add_variant_img_to_parent_image_array(record, hash)
+            add_variant_image!(hash, record)
+            add_variant_image_to_parent_images!(hash, record)
             record
           end
 
@@ -18,11 +18,14 @@ module ShopifyTransporter
             input['images'].present? && input['parent_id'].present?
           end
 
-          def accumulate(input, record)
-            current_product = record['variants'].select do |variant|
+          def current_variant(input, record)
+            record['variants'].select do |variant|
               variant['product_id'] == input['product_id']
             end.first
-            current_product.merge!(
+          end
+
+          def add_variant_image!(input, record)
+            current_variant(input, record).merge!(
               'variant_image' => {
                 'src' => variant_image_url(input),
               }
@@ -34,7 +37,7 @@ module ShopifyTransporter
             input['images'].sort_by { |image| image['position'] }.first['url']
           end
 
-          def add_variant_img_to_parent_image_array(record, input)
+          def add_variant_image_to_parent_images!(input, record)
             record['images'] ||= []
             record['images'] << {
               'src' => variant_image_url(input),

--- a/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
@@ -9,15 +9,21 @@ module ShopifyTransporter
         class VariantImage < Pipeline::Stage
           def convert(hash, record)
             return unless input_applied?(hash)
+<<<<<<< HEAD
             add_variant_image!(hash, record)
             add_variant_image_to_parent_images!(hash, record)
             record
+=======
+            accumulate(hash, record)
+            add_variant_img_to_parent_image_array(record, hash)
+>>>>>>> extract and convert variant images
           end
 
           def input_applied?(input)
             input['images'].present? && input['parent_id'].present?
           end
 
+<<<<<<< HEAD
           def current_variant(input, record)
             record['variants'].select do |variant|
               variant['product_id'] == input['product_id']
@@ -28,6 +34,18 @@ module ShopifyTransporter
             current_variant(input, record).merge!(
               'variant_image' => {
                 'src' => variant_image_url(input),
+=======
+
+          def accumulate(input, record)
+            current_product = record['variants'].select do |variant|
+              variant['product_id'] == input['product_id']
+            end.first
+            current_product.merge!(
+              {
+                'variant_image': {
+                  'src': variant_image_url(input)
+                }
+>>>>>>> extract and convert variant images
               }
             )
           end
@@ -37,10 +55,17 @@ module ShopifyTransporter
             input['images'].sort_by { |image| image['position'] }.first['url']
           end
 
+<<<<<<< HEAD
           def add_variant_image_to_parent_images!(input, record)
             record['images'] ||= []
             record['images'] << {
               'src' => variant_image_url(input),
+=======
+          def add_variant_img_to_parent_image_array(record, input)
+            record['images'] ||= []
+            record['images'] << {
+              'src': variant_image_url(input)
+>>>>>>> extract and convert variant images
             }
           end
         end

--- a/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
@@ -9,21 +9,15 @@ module ShopifyTransporter
         class VariantImage < Pipeline::Stage
           def convert(hash, record)
             return unless input_applied?(hash)
-<<<<<<< HEAD
             add_variant_image!(hash, record)
             add_variant_image_to_parent_images!(hash, record)
             record
-=======
-            accumulate(hash, record)
-            add_variant_img_to_parent_image_array(record, hash)
->>>>>>> extract and convert variant images
           end
 
           def input_applied?(input)
             input['images'].present? && input['parent_id'].present?
           end
 
-<<<<<<< HEAD
           def current_variant(input, record)
             record['variants'].select do |variant|
               variant['product_id'] == input['product_id']
@@ -34,18 +28,6 @@ module ShopifyTransporter
             current_variant(input, record).merge!(
               'variant_image' => {
                 'src' => variant_image_url(input),
-=======
-
-          def accumulate(input, record)
-            current_product = record['variants'].select do |variant|
-              variant['product_id'] == input['product_id']
-            end.first
-            current_product.merge!(
-              {
-                'variant_image': {
-                  'src': variant_image_url(input)
-                }
->>>>>>> extract and convert variant images
               }
             )
           end
@@ -55,17 +37,10 @@ module ShopifyTransporter
             input['images'].sort_by { |image| image['position'] }.first['url']
           end
 
-<<<<<<< HEAD
           def add_variant_image_to_parent_images!(input, record)
             record['images'] ||= []
             record['images'] << {
               'src' => variant_image_url(input),
-=======
-          def add_variant_img_to_parent_image_array(record, input)
-            record['images'] ||= []
-            record['images'] << {
-              'src': variant_image_url(input)
->>>>>>> extract and convert variant images
             }
           end
         end

--- a/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'shopify_transporter/pipeline/stage'
+require 'shopify_transporter/shopify'
+
+module ShopifyTransporter
+  module Pipeline
+    module Magento
+      module Product
+        class VariantImage < Pipeline::Stage
+          def convert(hash, record)
+            return unless input_applied?(hash)
+            accumulate(hash, record)
+            add_variant_img_to_parent_image_array(record, hash)
+          end
+
+          def input_applied?(input)
+            input['images'].present? && input['parent_id'].present?
+          end
+
+
+          def accumulate(input, record)
+            current_product = record['variants'].select do |variant|
+              variant['product_id'] == input['product_id']
+            end.first
+            current_product.merge!(
+              {
+                'variant_image': {
+                  'src': variant_image_url(input)
+                }
+              }
+            )
+          end
+
+          def variant_image_url(input)
+            return input['images']['url'] if input['images'].is_a?(Hash)
+            input['images'].sort_by { |image| image['position'] }.first['url']
+          end
+
+          def add_variant_img_to_parent_image_array(record, input)
+            record['images'] ||= []
+            record['images'] << {
+              'src': variant_image_url(input)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/variant_image.rb
@@ -11,22 +11,20 @@ module ShopifyTransporter
             return unless input_applied?(hash)
             accumulate(hash, record)
             add_variant_img_to_parent_image_array(record, hash)
+            record
           end
 
           def input_applied?(input)
             input['images'].present? && input['parent_id'].present?
           end
 
-
           def accumulate(input, record)
             current_product = record['variants'].select do |variant|
               variant['product_id'] == input['product_id']
             end.first
             current_product.merge!(
-              {
-                'variant_image': {
-                  'src': variant_image_url(input)
-                }
+              'variant_image' => {
+                'src' => variant_image_url(input),
               }
             )
           end
@@ -39,7 +37,7 @@ module ShopifyTransporter
           def add_variant_img_to_parent_image_array(record, input)
             record['images'] ||= []
             record['images'] << {
-              'src': variant_image_url(input)
+              'src' => variant_image_url(input),
             }
           end
         end

--- a/lib/shopify_transporter/shopify/product.rb
+++ b/lib/shopify_transporter/shopify/product.rb
@@ -75,7 +75,7 @@ module ShopifyTransporter
           variant = variant_hash.slice(*VARIANT_ATTRIBUTES)
           variant.transform_keys! { |k| "#{VARIANT_PREFIX}#{k}" }
           variant.merge!(variant_option_hash(variant_hash))
-          variant['variant_image'] = variant_hash[:variant_image] && variant_hash[:variant_image][:src]
+          variant['variant_image'] = variant_hash['variant_image'] && variant_hash['variant_image']['src']
           row_values_from(variant)
         end
       end

--- a/lib/shopify_transporter/shopify/product.rb
+++ b/lib/shopify_transporter/shopify/product.rb
@@ -75,7 +75,7 @@ module ShopifyTransporter
           variant = variant_hash.slice(*VARIANT_ATTRIBUTES)
           variant.transform_keys! { |k| "#{VARIANT_PREFIX}#{k}" }
           variant.merge!(variant_option_hash(variant_hash))
-          variant['variant_image'] = variant_hash['variant_image'] && variant_hash['variant_image']['src']
+          variant['variant_image'] = variant_hash[:variant_image] && variant_hash[:variant_image][:src]
           row_values_from(variant)
         end
       end

--- a/lib/templates/magento/config.tt
+++ b/lib/templates/magento/config.tt
@@ -21,6 +21,7 @@ object_types:
       - TopLevelAttributes
       - VariantAttributes
       - TopLevelVariantAttributes
+      - VariantImage
   order:
     record_key: increment_id
     pipeline_stages:

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -79,6 +79,26 @@ FactoryBot.define do
     sequence(:created_at) { '2013-03-05T01:25:10-05:00' }
     sequence(:published_scope) { 'web' }
 
+    trait :with_img do
+      images do
+        [
+          {
+            "position": "1",
+            "src": "parent_img_position_1",
+          },
+          {
+            "position": "2",
+            "src": "parent_img_position_2",
+          },
+          {
+            "position": "4",
+            "src": "parent_img_position_4",
+          }
+        ]
+
+      end
+    end
+
     initialize_with { attributes.deep_stringify_keys }
   end
 
@@ -92,6 +112,23 @@ FactoryBot.define do
     sequence(:created_at) { '2013-03-05T01:25:10-05:00' }
     sequence(:published_scope) { 'web' }
     sequence(:parent_id) { '1' }
+
+    trait :with_img do
+      images do
+        [
+          {
+            "file": "/m/s/msj000a_1.jpg",
+            "position": "2",
+            "url": "child_img_position_2",
+          },
+          {
+            "file": "/m/s/msj000c_1.jpg",
+            "position": "4",
+            "url": "child_img_position_4",
+          }
+        ]
+      end
+    end
 
     initialize_with { attributes.deep_stringify_keys }
   end

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -83,6 +83,57 @@ module ShopifyTransporter::Pipeline::Magento::Product
 
           expect(shopify_product.deep_stringify_keys).to include(expected_shopify_product_image.deep_stringify_keys)
         end
+
+        it 'Merge the parent image with the existing image arrays if child products get processed before parent product does' do
+          record = {
+            'images' => [
+              {
+                'src' => 'example_child_image_1'
+              },
+              {
+                'src' => 'example_child_image_2'
+              }
+            ]
+          }
+          parent_product = FactoryBot.build(:configurable_magento_product, 'images' => [
+            {
+              'position' => '1',
+              'url' => 'parent_img_position_1',
+            },
+            {
+              'position' => '2',
+              'url' => 'parent_img_position_2',
+            },
+            {
+              'position' => '4',
+              'url'=> 'parent_img_position_4',
+            }
+          ])
+          shopify_product = described_class.new.convert(parent_product, record)
+
+          expected_image_response = [
+            {
+              'src' => 'example_child_image_1'
+            },
+            {
+              'src' => 'example_child_image_2'
+            },
+            {
+              'position' => '1',
+              'src' => 'parent_img_position_1',
+            },
+            {
+              'position'=> '2',
+              'src' => 'parent_img_position_2',
+            },
+            {
+              'position' => '4',
+              'src' => 'parent_img_position_4',
+            }
+          ]
+          expect(shopify_product['images']).to eq (expected_image_response)
+
+        end
       end
     end
   end

--- a/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/variant_image'
-
+require 'pry'
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe VariantImage, type: :helper do
     context '#convert' do
@@ -35,6 +35,50 @@ module ShopifyTransporter::Pipeline::Magento::Product
 
         expect(shopify_product['images']).to eq  expected_parent_image_info
         expect(shopify_product['variants'].first).to include  expected_variant_image_info
+      end
+
+      it 'should work when there are multiple child products with variant images' do
+        simple_product_with_img = FactoryBot.build(:simple_magento_product, :with_img)
+        another_simple_product_with_img = FactoryBot.build(:simple_magento_product, 'product_id': '3', 'images': [
+          {
+            "file": "child_img_position_1",
+            "position": "1",
+            "url": "child_img_position_1",
+          },
+          {
+            "file": "child_img_position_5",
+            "position": "5",
+            "url": "child_img_position_5",
+          }
+        ])
+        configurable_product = FactoryBot.build(:configurable_magento_product,'variants': [simple_product_with_img, another_simple_product_with_img])
+        shopify_product = described_class.new.convert(simple_product_with_img, configurable_product)
+        shopify_product = described_class.new.convert(another_simple_product_with_img, configurable_product)
+        expected_variant_image_info = {
+          'simple_product_with_img' => {
+            'variant_image' => {
+              'src' => 'child_img_position_2'
+            }
+          },
+          'another_simple_product_with_img' => {
+            'variant_image' => {
+              'src' => 'child_img_position_1'
+            }
+          }
+        }
+
+        expected_parent_image_info = [
+          {
+            'src' => 'child_img_position_2'
+          },
+          {
+            'src' => 'child_img_position_1'
+          }
+        ]
+
+        expect(shopify_product['images']).to eq  expected_parent_image_info
+        expect(shopify_product['variants'].first).to include  expected_variant_image_info['simple_product_with_img']
+        expect(shopify_product['variants'][1]).to include  expected_variant_image_info['another_simple_product_with_img']
       end
 
       it 'should skip variant image conversion if the child product has no image attached' do

--- a/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/variant_image'
-
+require 'pry'
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe VariantImage, type: :helper do
     context '#convert' do

--- a/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/variant_image'
-require 'pry'
+
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe VariantImage, type: :helper do
     context '#convert' do

--- a/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'shopify_transporter/pipeline/magento/product/variant_image'
+
+module ShopifyTransporter::Pipeline::Magento::Product
+  RSpec.describe VariantImage, type: :helper do
+    context '#convert' do
+      it 'should extract the correct image as the variant image and add that to the parent image list' do
+        simple_product_with_img = FactoryBot.build(:simple_magento_product, :with_img)
+        configurable_product_with_img = FactoryBot.build(:configurable_magento_product, :with_img, 'variants': [simple_product_with_img])
+        shopify_product = described_class.new.convert(simple_product_with_img, configurable_product_with_img)
+        expected_variant_image_info = {
+          'variant_image' => {
+            'src' => 'child_img_position_2'
+          }
+        }
+
+        expected_parent_image_info = [
+          {
+            'position' => '1',
+            'src' => 'parent_img_position_1'
+          },
+          {
+            'position' => '2',
+            'src' => 'parent_img_position_2'
+          },
+          {
+            'position' => "4",
+            'src' => 'parent_img_position_4'
+          },
+          {
+            'src' => 'child_img_position_2'
+          }
+        ]
+
+        expect(shopify_product['images']).to eq  expected_parent_image_info
+        expect(shopify_product['variants'].first).to include  expected_variant_image_info
+      end
+
+      it 'should skip variant image conversion if the child product has no image attached' do
+        simple_product_without_img = FactoryBot.build(:simple_magento_product)
+        configurable_product_with_img = FactoryBot.build(:configurable_magento_product, :with_img, 'variants': [simple_product_without_img])
+        should_skip_conversion = described_class.new.convert(simple_product_without_img, configurable_product_with_img).nil?
+        expect(should_skip_conversion).to be true
+      end
+
+      it 'should skip variant image conversion if the input product is not a child product' do
+        magento_product = FactoryBot.build(:magento_product)
+        configurable_product_with_img = FactoryBot.build(:configurable_magento_product, :with_img, 'variants': [magento_product])
+        should_skip_conversion = described_class.new.convert(magento_product, configurable_product_with_img).nil?
+        expect(should_skip_conversion).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What it does and why:
- Code extracting variant images already exists
- Add a new pipeline stage to convert variant images

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

### Demo:
<img width="913" alt="screen shot 2018-09-27 at 11 26 07 am" src="https://user-images.githubusercontent.com/21313470/46156746-2b9ddd00-c248-11e8-959a-9e97294395a7.png">


---

### Related issues: https://github.com/Shopify/transporter_app/issues/1325
Closes:
