### PR TITLE
Write data incrementally to stdout

### DIFF
--- a/lib/shopify_transporter/exporters/magento/customer_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/customer_exporter.rb
@@ -9,15 +9,21 @@ module ShopifyTransporter
           @database_adapter = database_adapter
         end
 
+        def key
+          :customer_id
+        end
+
         def export
-          $stderr.puts 'Starting export...'
-          base_customers.map do |customer|
-            $stderr.puts "Fetching customer: #{customer[:customer_id]}..."
-            customer.merge(address_list: customer_address_list(customer[:customer_id]))
-          end.compact
+          base_customers.each do |customer|
+            yield with_attributes(customer)
+          end
         end
 
         private
+
+        def with_attributes(base_customer)
+          base_customer.merge(address_list: customer_address_list(base_customer[:customer_id]))
+        end
 
         def base_customers
           result = @client.call(:customer_customer_list, filters: nil).body

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -9,15 +9,21 @@ module ShopifyTransporter
           @database_adapter = database_adapter
         end
 
+        def key
+          :increment_id
+        end
+
         def export
-          $stderr.puts 'Starting export...'
-          base_orders.map do |order|
-            $stderr.puts "Fetching order: #{order[:increment_id]}..."
-            order.merge(items: info_for(order[:increment_id]))
-          end.compact
+          base_orders.each do |order|
+            yield with_attributes(order)
+          end
         end
 
         private
+
+        def with_attributes(base_order)
+          base_order.merge(items: info_for(base_order[:increment_id]))
+        end
 
         def base_orders
           result = @client.call(:sales_order_list, filters: nil).body

--- a/lib/shopify_transporter/exporters/magento/product_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/product_exporter.rb
@@ -12,13 +12,14 @@ module ShopifyTransporter
           @intermediate_file_name = 'magento_product_mappings.csv'
         end
 
+        def key
+          :product_id
+        end
+
         def export
-          $stderr.puts 'Starting export...'
-          products = base_products.map do |product|
-            $stderr.puts "Fetching product: #{product[:product_id]}"
-            with_attributes(product)
-          end.compact
-          apply_mappings(products)
+          apply_mappings(base_products).each do |product|
+            yield with_attributes(product)
+          end
         end
 
         private

--- a/spec/shopify_transporter/exporters/exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/exporter_spec.rb
@@ -7,8 +7,14 @@ module ShopifyTransporter
       class SomePlatformExporter
         def initialize(_)
         end
+        def key
+          :foo
+        end
         def export
-          [{ foo: 'bar' }]
+          objects = [{ foo: 'bar' }, { baz: 'gud' }]
+          objects.each do |object|
+            yield object
+          end
         end
       end
 
@@ -54,7 +60,10 @@ module ShopifyTransporter
           .and_return(SomePlatformExporter)
 
         exporter = Exporter.new(config_file.path, :unused)
-        expect { exporter.run }.to output(JSON.pretty_generate([{ foo: 'bar' }]) + $INPUT_RECORD_SEPARATOR).to_stdout
+
+        expected_result = [{ 'foo' => 'bar' }, { 'baz' => 'gud' }]
+        output = capture(:stdout) { exporter.run }
+        expect(JSON.parse(output)).to eq(expected_result)
       end
 
       it 'raises InvalidConfigError if config file does not exist' do

--- a/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/customer_exporter_spec.rb
@@ -4,6 +4,12 @@ module ShopifyTransporter
   module Exporters
     module Magento
       RSpec.describe CustomerExporter do
+        context '#key' do
+          it 'returns :customer_id' do
+            expect(described_class.new.key).to eq(:customer_id)
+          end
+        end
+
         context '#run' do
           it 'retrieves customers from Magento using the SOAP API and returns the results' do
             soap_client = double("soap client")
@@ -44,24 +50,22 @@ module ShopifyTransporter
               },
             ).at_least(:once)
 
-            expected_result = [
-              {
-                customer_id: '654321',
-                top_level_attribute: "an_attribute",
-                address_list: {
-                  customer_address_list_response: {
-                    result: {
-                      item: {
-                        customer_address_attribute: "another_attribute",
-                      }
+            expected_result =  {
+              customer_id: '654321',
+              top_level_attribute: "an_attribute",
+              address_list: {
+                customer_address_list_response: {
+                  result: {
+                    item: {
+                      customer_address_attribute: "another_attribute",
                     }
-                  },
+                  }
                 },
               },
-            ]
+            }
 
             exporter = described_class.new(soap_client: soap_client)
-            expect(exporter.export).to eq(expected_result)
+            expect { |block| exporter.export(&block) }.to yield_with_args(expected_result)
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
@@ -5,6 +5,12 @@ module ShopifyTransporter
   module Exporters
     module Magento
       RSpec.describe OrderExporter do
+        context '#key' do
+          it 'returns :increment_id' do
+            expect(described_class.new.key).to eq(:increment_id)
+          end
+        end
+
         context '#run' do
           it 'retrieves orders from Magento using the SOAP API and returns the results' do
             soap_client = double("soap client")
@@ -43,20 +49,18 @@ module ShopifyTransporter
               },
             ).at_least(:once)
 
-            expected_result = [
-              {
-                increment_id: '12345',
-                top_level_attribute: "an_attribute",
-                items: {
-                  result: {
-                    order_info_attribute: "another_attribute",
-                  }
-                },
+            expected_result = {
+              increment_id: '12345',
+              top_level_attribute: "an_attribute",
+              items: {
+                result: {
+                  order_info_attribute: "another_attribute",
+                }
               },
-            ]
+            }
 
             exporter = described_class.new(soap_client: soap_client)
-            expect(exporter.export).to eq(expected_result)
+            expect { |block| exporter.export(&block) }.to yield_with_args(expected_result)
           end
         end
       end

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
-require 'pry'
 
 module ShopifyTransporter
   module Exporters

--- a/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_exporter_spec.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
+require 'pry'
 
 module ShopifyTransporter
   module Exporters
     module Magento
       RSpec.describe ProductExporter do
+        context '#key' do
+          it 'returns :product_id' do
+            expect(described_class.new.key).to eq(:product_id)
+          end
+        end
+
         context '#run'
           it 'retrieves configurable products from Magento using the SOAP API and returns the results' do
             soap_client = double("soap client")
@@ -86,30 +93,28 @@ module ShopifyTransporter
               }
             )
 
-            expected_result = [
-              {
-                product_id: '12345',
-                type: 'configurable',
-                top_level_attribute: "an_attribute",
-                attribute_key: "another_attribute",
-                images: [{ url: :img_src }, { url: :img_src2 }],
-                tags: [
-                  {
-                    "tag_id": "17",
-                    "name": "white",
-                    "@xsi:type": "ns1:catalogProductTagListEntity"
-                  },
-                  {
-                    "tag_id": "18",
-                    "name": "shirt",
-                    "@xsi:type": "ns1:catalogProductTagListEntity"
-                  }
-                ]
-              },
-            ]
+            expected_result = {
+              product_id: '12345',
+              type: 'configurable',
+              top_level_attribute: "an_attribute",
+              attribute_key: "another_attribute",
+              images: [{ url:  :img_src }, { url:  :img_src2 }],
+              tags: [
+                {
+                  tag_id: '17',
+                  name: 'white',
+                  '@xsi:type': 'ns1:catalogProductTagListEntity'
+                },
+                {
+                  tag_id: '18',
+                  name: 'shirt',
+                  '@xsi:type': 'ns1:catalogProductTagListEntity'
+                }
+              ]
+            }
 
             exporter = described_class.new(soap_client: soap_client)
-            expect(exporter.export).to eq(expected_result)
+            expect { |block| exporter.export(&block) }.to yield_with_args(expected_result)
           end
 
           context '#parent_id' do
@@ -214,29 +219,27 @@ module ShopifyTransporter
                   }
                 }
               )
-              expected_result = [
-                {
-                  product_id: '801',
-                  top_level_attribute: "an_attribute",
-                  type: 'simple',
-                  parent_id: '12345',
-                  inventory_quantity: 5,
-                  attribute_key: "another_attribute",
-                  images: [{ url: :img_src }, { url: :img_src2 }],
-                  tags: [
-                    {
-                      "tag_id": "17",
-                      "name": "white",
-                      "@xsi:type": "ns1:catalogProductTagListEntity"
-                    },
-                    {
-                      "tag_id": "18",
-                      "name": "shirt",
-                      "@xsi:type": "ns1:catalogProductTagListEntity"
-                    }
-                  ]
-                },
-              ]
+              expected_result = {
+                product_id: '801',
+                top_level_attribute: "an_attribute",
+                type: 'simple',
+                parent_id: '12345',
+                inventory_quantity: 5,
+                attribute_key: "another_attribute",
+                images: [{ url:  :img_src }, { url:  :img_src2 }],
+                tags: [
+                  {
+                    tag_id: "17",
+                    name: "white",
+                    "@xsi:type": "ns1:catalogProductTagListEntity"
+                  },
+                  {
+                    tag_id: "18",
+                    name: "shirt",
+                    "@xsi:type": "ns1:catalogProductTagListEntity"
+                  }
+                ]
+              }
 
               mappings = <<~EOS
                 product_id,associated_product_id
@@ -250,7 +253,7 @@ module ShopifyTransporter
               in_temp_folder do
                 File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
                 exporter = described_class.new(soap_client: soap_client, database_adapter: nil)
-                expect(exporter.export).to eq(expected_result)
+                expect { |block| exporter.export(&block) }.to yield_with_args(expected_result)
               end
             end
 
@@ -343,28 +346,26 @@ module ShopifyTransporter
                 }
               )
 
-              expected_result = [
-                {
-                  product_id: '801',
-                  type: 'simple',
-                  top_level_attribute: "an_attribute",
-                  inventory_quantity: 5,
-                  another_key: "another_attribute",
-                  images: [{ url: :img_src }, { url: :img_src2 }],
-                  tags: [
-                    {
-                      "tag_id": "17",
-                      "name": "white",
-                      "@xsi:type": "ns1:catalogProductTagListEntity"
-                    },
-                    {
-                      "tag_id": "18",
-                      "name": "shirt",
-                      "@xsi:type": "ns1:catalogProductTagListEntity"
-                    }
-                  ]
-                },
-              ]
+              expected_result = {
+                product_id: '801',
+                type: 'simple',
+                top_level_attribute: "an_attribute",
+                inventory_quantity: 5,
+                another_key: "another_attribute",
+                images: [{ url:  :img_src }, { url:  :img_src2 }],
+                tags: [
+                  {
+                    tag_id: "17",
+                    name: "white",
+                    "@xsi:type": "ns1:catalogProductTagListEntity"
+                  },
+                  {
+                    tag_id: "18",
+                    name: "shirt",
+                    "@xsi:type": "ns1:catalogProductTagListEntity"
+                  }
+                ]
+              }
 
               mappings = <<~EOS
                 product_id,associated_product_id
@@ -378,7 +379,7 @@ module ShopifyTransporter
               in_temp_folder do
                 File.open('magento_product_mappings.csv', 'w') { |file| file.write(mappings) }
                 exporter = described_class.new(soap_client: soap_client, database_adapter: nil)
-                expect(exporter.export).to eq(expected_result)
+                expect { |block| exporter.export(&block) }.to yield_with_args(expected_result)
               end
             end
           end

--- a/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/variant_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shopify_transporter/pipeline/magento/product/variant_image'
-require 'pry'
+
 module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe VariantImage, type: :helper do
     context '#convert' do


### PR DESCRIPTION
### What it does and why:

Print the output as we get it instead of all at the end. This means that if something goes wrong midway, instead of losing all the work done so far, the user can see what was done. This is a step in the right direction so that using the exporters for large data sets will be less painful.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
This is the first half of work related to https://github.com/Shopify/transporter_app/issues/1282
