### PR TITLE
update config template with new product object type and export config

### DIFF
--- a/lib/templates/magento/config.tt
+++ b/lib/templates/magento/config.tt
@@ -15,9 +15,28 @@ object_types:
             - website
             - group
             - free_trial_start_at
+  product:
+    record_key: product_id 
+    pipeline_stages:
+      - TopLevelAttributes
+      - VariantAttributes
+      - TopLevelVariantAttributes
   order:
     record_key: increment_id
     pipeline_stages:
       - TopLevelAttributes
       - LineItems
       - AddressesAttribute
+
+export_configuration:
+  soap:
+    hostname:
+    username:
+    api_key:
+  database:
+    host:
+    port: 3306
+    user:
+    password:
+    database:
+  store_id:


### PR DESCRIPTION


### What it does and why:
- When generating a new project using the `new` command, we now populate the `config.yml` with the new product object type and export configuration options so that the `export` command can pull data from a Magento database instance and from the SOAP API.

What the new config.yml looks like now:
![image](https://user-images.githubusercontent.com/22937651/46158096-268e5d00-c24b-11e8-8dbc-6204011ac6e9.png)

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/transporter_app/issues/1331
