### PR TITLE
Refactor variant pipeline tests to test that record is mutated

### DIFF
--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -96,7 +96,7 @@ FactoryBot.define do
     initialize_with { attributes.deep_stringify_keys }
   end
 
-  factory :advanced_configurable_product, class: Hash do
+  factory :advanced_magento_configurable_product, class: Hash do
     skip_create
 
     sequence(:product_id) { '3' }
@@ -108,7 +108,7 @@ FactoryBot.define do
     initialize_with { attributes.deep_stringify_keys }
   end
 
-  factory :advanced_simple_product, class: Hash do
+  factory :advanced_magento_simple_product, class: Hash do
     skip_create
 
     sequence(:product_id) { |n| n }

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -6,17 +6,29 @@ module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe TopLevelVariantAttributes, type: :helper do
     context '#convert' do
       it 'extracts top level product variant attributes from an input hash' do
-        child_product = FactoryBot.build(:advanced_simple_product)
-        parent_product = FactoryBot.build(:advanced_configurable_product, {variants: [child_product]})
-        variants_in_shopify_format = described_class.new.convert(child_product, parent_product)
-        expected_variants_in_shopify_format = {
-          sku: child_product['sku'],
-          grams: child_product['weight'],
-          price: child_product['price'],
-          inventory_qty: child_product['inventory_quantity'],
+        child_product = FactoryBot.build(:advanced_magento_simple_product)
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': child_product['product_id'],
+            },
+          ])
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              sku: child_product['sku'],
+              grams: child_product['weight'],
+              price: child_product['price'],
+              inventory_qty: child_product['inventory_quantity'],
+            }
+          ]
         }
 
-        expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
       end
 
       it 'ignores attributes that are not explicitly specified in the top-level' do
@@ -25,40 +37,70 @@ module ShopifyTransporter::Pipeline::Magento::Product
           nonsense_key: :foo,
           nonsense_namespace: :bar,
         }
-        child_product = FactoryBot.build(:advanced_simple_product, with_nonsense)
-        parent_product = FactoryBot.build(:advanced_configurable_product, {variants: [child_product]})
-        variants_in_shopify_format = described_class.new.convert(child_product, parent_product)
-        expected_variants_in_shopify_format = {
-          sku: child_product['sku'],
-          grams: child_product['weight'],
-          price: child_product['price'],
-          inventory_qty: child_product['inventory_quantity'],
+        child_product = FactoryBot.build(:advanced_magento_simple_product, with_nonsense)
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': child_product['product_id'],
+            },
+          ])
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              sku: child_product['sku'],
+              grams: child_product['weight'],
+              price: child_product['price'],
+              inventory_qty: child_product['inventory_quantity'],
+            }
+          ]
         }
 
-        expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
       end
 
       it 'make sure the correct product is being converted when there exist multiple simple products as variants' do
-        child_product = FactoryBot.build(:advanced_simple_product)
-        another_child_product = FactoryBot.build(:advanced_simple_product)
-        parent_product = FactoryBot.build(:advanced_configurable_product, {variants: [child_product, another_child_product]})
-        variants_in_shopify_format = described_class.new.convert(child_product, parent_product)
-        expected_variants_in_shopify_format = {
-          product_id: child_product['product_id'],
-          sku: child_product['sku'],
-          grams: child_product['weight'],
-          price: child_product['price'],
-          inventory_qty: child_product['inventory_quantity'],
+        child_product = FactoryBot.build(:advanced_magento_simple_product)
+        another_child_product = FactoryBot.build(:advanced_magento_simple_product)
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': child_product['product_id'],
+            },
+            {
+              'product_id': another_child_product['product_id'],
+            },
+          ])
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              sku: child_product['sku'],
+              grams: child_product['weight'],
+              price: child_product['price'],
+              inventory_qty: child_product['inventory_quantity'],
+            },
+            {
+              product_id: another_child_product['product_id'],
+            },
+          ],
         }
 
-        expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
       end
 
       it 'should skip converting top level variants when the input is a product without parent_id' do
+        parent_product = {}
         simple_product_without_parent = FactoryBot.build(:simple_magento_product)
-        simple_product_without_parent.delete("parent_id")
-        variants_in_shopify_format = described_class.new.convert(simple_product_without_parent, {})
-        expect(variants_in_shopify_format).to be_nil
+        simple_product_without_parent.delete('parent_id')
+        described_class.new.convert(simple_product_without_parent, parent_product)
+        expect(parent_product.keys).not_to include(:variants)
       end
     end
   end


### PR DESCRIPTION
### What it does and why:
- Updates variant tests to test that record is mutated instead of testing the output of convert.

### Checklist:

- [X] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.