### PR TITLE
Convert product options

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -32,6 +32,7 @@ module ShopifyTransporter
               attributes['published_at'] = published?(input) ? input['updated_at'] : ''
               append_images_to_current_record!(input) if input['images'].present?
               attributes['tags'] = product_tags(input) if input['tags'].present?
+              attributes['options'] = product_options(input) if input['option1_name'].present?
               attributes
             end
 
@@ -56,6 +57,12 @@ module ShopifyTransporter
                 @output['images'].concat(images)
               else
                 @output['images'] = images
+              end
+            end
+
+            def product_options(input)
+              %w(option1_name option2_name option3_name).map do |option_name|
+                { 'name' => input[option_name] }
               end
             end
 

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
@@ -30,6 +30,17 @@ module ShopifyTransporter
 
             def accumulate(input)
               accumulate_attributes(map_from_key_to_val(COLUMN_MAPPING, input))
+              accumulate_attributes(variant_options(input))
+            end
+
+            private
+
+            def variant_options(input)
+              {
+                'option1' => input['option1_value'],
+                'option2' => input['option2_value'],
+                'option3' => input['option3_value'],
+              }.compact
             end
           end
         end

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -53,6 +53,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_product_options do
+      option1_name 'Color'
+      option2_name 'Size'
+      option3_name 'Style'
+    end
+
     initialize_with { attributes.deep_stringify_keys }
   end
 

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -133,7 +133,7 @@ FactoryBot.define do
     initialize_with { attributes.deep_stringify_keys }
   end
 
-  factory :advanced_configurable_product, class: Hash do
+  factory :advanced_magento_configurable_product, class: Hash do
     skip_create
 
     sequence(:product_id) { '3' }
@@ -145,7 +145,7 @@ FactoryBot.define do
     initialize_with { attributes.deep_stringify_keys }
   end
 
-  factory :advanced_simple_product, class: Hash do
+  factory :advanced_magento_simple_product, class: Hash do
     skip_create
 
     sequence(:product_id) { |n| n }

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -52,6 +52,56 @@ module ShopifyTransporter::Pipeline::Magento::Product
         expect(shopify_product.deep_stringify_keys).to include(expected_product_tag_info.deep_stringify_keys)
       end
 
+      describe 'product options' do
+        it 'extracts product options when there are three options' do
+          magento_product = FactoryBot.build(:magento_product, :with_product_options)
+          shopify_product = described_class.new.convert(magento_product, {})
+          expected_option_data = {
+            options: [
+              {
+                'name': 'Color',
+              },
+              {
+                'name': 'Size',
+              },
+              {
+                'name': 'Style',
+              },
+            ],
+          }
+          expect(shopify_product.deep_stringify_keys).to include(expected_option_data.deep_stringify_keys)
+        end
+
+        it 'extracts product options when there are less than three options' do
+          magento_product = FactoryBot.build(:magento_product)
+          magento_product['option1_name'] = 'Color'
+          shopify_product = described_class.new.convert(magento_product, {})
+          expected_option_data = {
+            options: [
+              {
+                'name': 'Color',
+              },
+              {
+                'name': nil,
+              },
+              {
+                'name': nil,
+              },
+            ],
+          }
+          expect(shopify_product.deep_stringify_keys).to include(expected_option_data.deep_stringify_keys)
+        end
+
+        it 'does not extract product options when there are no options' do
+          magento_product = FactoryBot.build(:magento_product)
+          shopify_product = described_class.new.convert(magento_product, {})
+
+          expect(shopify_product.keys).not_to include('options')
+        end
+      end
+
+
+
       context '#images' do
         it 'handles images with no labels' do
           magento_product = FactoryBot.build(:magento_product, :with_no_label_image)

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -102,6 +102,96 @@ module ShopifyTransporter::Pipeline::Magento::Product
         described_class.new.convert(simple_product_without_parent, parent_product)
         expect(parent_product.keys).not_to include(:variants)
       end
+
+      it 'extracts option information correctly when there are 3 options present' do
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': '111',
+            },
+          ])
+
+        child_product = {
+          'product_id' => '111',
+          'parent_id' => parent_product['product_id'],
+          'option1_name' => 'Color',
+          'option1_value' => 'White',
+          'option2_name' => 'Size',
+          'option2_value' => 'XS',
+          'option3_name' => 'Style',
+          'option3_value' => 'T-Shirt',
+        }
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              option1: 'White',
+              option2: 'XS',
+              option3: 'T-Shirt',
+            },
+          ],
+        }
+
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
+      end
+
+      it 'extracts option information correctly when there is only 1 option present' do
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': '111',
+            },
+          ])
+
+        child_product = {
+          'product_id' => '111',
+          'parent_id' => parent_product['product_id'],
+          'option1_name' => 'Color',
+          'option1_value' => 'White',
+        }
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              option1: 'White',
+            },
+          ],
+        }
+
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
+      end
+
+      it "does not extract option information if it isn't present" do
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': '111',
+            },
+          ])
+
+        child_product = {
+          'product_id' => '111',
+          'parent_id' => parent_product['product_id'],
+        }
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+            },
+          ],
+        }
+
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
+      end
     end
   end
 end

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_variant_attributes_spec.rb
@@ -6,17 +6,29 @@ module ShopifyTransporter::Pipeline::Magento::Product
   RSpec.describe TopLevelVariantAttributes, type: :helper do
     context '#convert' do
       it 'extracts top level product variant attributes from an input hash' do
-        child_product = FactoryBot.build(:advanced_simple_product)
-        parent_product = FactoryBot.build(:advanced_configurable_product, {variants: [child_product]})
-        variants_in_shopify_format = described_class.new.convert(child_product, parent_product)
-        expected_variants_in_shopify_format = {
-          sku: child_product['sku'],
-          grams: child_product['weight'],
-          price: child_product['price'],
-          inventory_qty: child_product['inventory_quantity'],
+        child_product = FactoryBot.build(:advanced_magento_simple_product)
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': child_product['product_id'],
+            },
+          ])
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              sku: child_product['sku'],
+              grams: child_product['weight'],
+              price: child_product['price'],
+              inventory_qty: child_product['inventory_quantity'],
+            }
+          ]
         }
 
-        expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
       end
 
       it 'ignores attributes that are not explicitly specified in the top-level' do
@@ -25,40 +37,70 @@ module ShopifyTransporter::Pipeline::Magento::Product
           nonsense_key: :foo,
           nonsense_namespace: :bar,
         }
-        child_product = FactoryBot.build(:advanced_simple_product, with_nonsense)
-        parent_product = FactoryBot.build(:advanced_configurable_product, {variants: [child_product]})
-        variants_in_shopify_format = described_class.new.convert(child_product, parent_product)
-        expected_variants_in_shopify_format = {
-          sku: child_product['sku'],
-          grams: child_product['weight'],
-          price: child_product['price'],
-          inventory_qty: child_product['inventory_quantity'],
+        child_product = FactoryBot.build(:advanced_magento_simple_product, with_nonsense)
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': child_product['product_id'],
+            },
+          ])
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              sku: child_product['sku'],
+              grams: child_product['weight'],
+              price: child_product['price'],
+              inventory_qty: child_product['inventory_quantity'],
+            }
+          ]
         }
 
-        expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
       end
 
       it 'make sure the correct product is being converted when there exist multiple simple products as variants' do
-        child_product = FactoryBot.build(:advanced_simple_product)
-        another_child_product = FactoryBot.build(:advanced_simple_product)
-        parent_product = FactoryBot.build(:advanced_configurable_product, {variants: [child_product, another_child_product]})
-        variants_in_shopify_format = described_class.new.convert(child_product, parent_product)
-        expected_variants_in_shopify_format = {
-          product_id: child_product['product_id'],
-          sku: child_product['sku'],
-          grams: child_product['weight'],
-          price: child_product['price'],
-          inventory_qty: child_product['inventory_quantity'],
+        child_product = FactoryBot.build(:advanced_magento_simple_product)
+        another_child_product = FactoryBot.build(:advanced_magento_simple_product)
+        parent_product = FactoryBot.build(:advanced_magento_configurable_product,
+          variants: [
+            {
+              'product_id': child_product['product_id'],
+            },
+            {
+              'product_id': another_child_product['product_id'],
+            },
+          ])
+
+        described_class.new.convert(child_product, parent_product)
+
+        expected_variant_information = {
+          variants: [
+            {
+              product_id: child_product['product_id'],
+              sku: child_product['sku'],
+              grams: child_product['weight'],
+              price: child_product['price'],
+              inventory_qty: child_product['inventory_quantity'],
+            },
+            {
+              product_id: another_child_product['product_id'],
+            },
+          ],
         }
 
-        expect(variants_in_shopify_format).to include(expected_variants_in_shopify_format.deep_stringify_keys)
+        expect(parent_product).to include(expected_variant_information.deep_stringify_keys)
       end
 
       it 'should skip converting top level variants when the input is a product without parent_id' do
+        parent_product = {}
         simple_product_without_parent = FactoryBot.build(:simple_magento_product)
-        simple_product_without_parent.delete("parent_id")
-        variants_in_shopify_format = described_class.new.convert(simple_product_without_parent, {})
-        expect(variants_in_shopify_format).to be_nil
+        simple_product_without_parent.delete('parent_id')
+        described_class.new.convert(simple_product_without_parent, parent_product)
+        expect(parent_product.keys).not_to include(:variants)
       end
     end
   end


### PR DESCRIPTION
### What it does and why:
- Converts product options to the format expected from the extracted magento data.
- Updates variant tests to test that record is mutated instead of testing the output of convert.

### Demo
Demo of the output data from a sample conversion:

![preview products csv shopify_transporter_projects 2018-09-27 15-03-30](https://user-images.githubusercontent.com/80290/46168507-b392df80-c266-11e8-99c6-db1b1fccdf26.png)


### Checklist:

- [X] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.
