### PR TITLE
display warnings if the product has more than 3 options

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -7,19 +7,25 @@ module ShopifyTransporter
     module Magento
       module Product
         class TopLevelAttributes < Pipeline::Stage
-          MAX_NUM_OF_OPTIONS_ACCEPTED = 3
-
           def convert(hash, record)
-            if has_too_many_options?(hash)
-              $stderr.puts "Warning: Product #{hash['product_id']} has too many options."\
-              " Only the first #{MAX_NUM_OF_OPTIONS_ACCEPTED} options will be converted."
-            end
+            warn_if_too_many_options(hash)
             accumulator = TopLevelAttributesAccumulator.new(record)
             accumulator.accumulate(hash)
           end
 
-          def has_too_many_options?(input)
+          private
+
+          MAX_NUM_OF_OPTIONS_ACCEPTED = 3
+
+          def too_many_options?(input)
             input["option#{MAX_NUM_OF_OPTIONS_ACCEPTED + 1}_name"].present?
+          end
+
+          def warn_if_too_many_options(input)
+            if too_many_options?(input)
+              $stderr.puts "Warning: Product #{input['product_id']} has too many options."\
+              " Only the first #{MAX_NUM_OF_OPTIONS_ACCEPTED} options will be converted."
+            end
           end
 
           class TopLevelAttributesAccumulator < Shopify::AttributesAccumulator

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -7,9 +7,19 @@ module ShopifyTransporter
     module Magento
       module Product
         class TopLevelAttributes < Pipeline::Stage
+          MAX_NUM_OF_OPTIONS_ACCEPTED = 3
+
           def convert(hash, record)
+            if has_too_many_options?(hash)
+              $stderr.puts "Warning: Product #{hash['product_id']} has too many options."\
+              " Only the first #{MAX_NUM_OF_OPTIONS_ACCEPTED} options will be converted."
+            end
             accumulator = TopLevelAttributesAccumulator.new(record)
             accumulator.accumulate(hash)
+          end
+
+          def has_too_many_options?(input)
+            input["option#{MAX_NUM_OF_OPTIONS_ACCEPTED + 1}_name"].present?
           end
 
           class TopLevelAttributesAccumulator < Shopify::AttributesAccumulator

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -15,16 +15,16 @@ module ShopifyTransporter
 
           private
 
-          MAX_NUM_OF_OPTIONS_ACCEPTED = 3
+          MAX_OPTION_COUNT = 3
 
           def too_many_options?(input)
-            input["option#{MAX_NUM_OF_OPTIONS_ACCEPTED + 1}_name"].present?
+            input["option#{MAX_OPTION_COUNT + 1}_name"].present?
           end
 
           def warn_if_too_many_options(input)
             if too_many_options?(input)
               $stderr.puts "Warning: Product #{input['product_id']} has too many options."\
-              " Only the first #{MAX_NUM_OF_OPTIONS_ACCEPTED} options will be converted."
+              " Only the first #{MAX_OPTION_COUNT} options will be converted."
             end
           end
 

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -92,6 +92,29 @@ module ShopifyTransporter::Pipeline::Magento::Product
           expect(shopify_product.deep_stringify_keys).to include(expected_option_data.deep_stringify_keys)
         end
 
+        it 'ignore the rest of options when there are more than three options' do
+          magento_product = FactoryBot.build(:magento_product)
+          magento_product['option1_name'] = 'option1'
+          magento_product['option2_name'] = 'option2'
+          magento_product['option3_name'] = 'option3'
+          magento_product['option4_name'] = 'option4'
+          shopify_product = described_class.new.convert(magento_product, {})
+          expected_option_data = {
+            options: [
+              {
+                'name': 'option1',
+              },
+              {
+                'name': 'option2',
+              },
+              {
+                'name': 'option3',
+              },
+            ],
+          }
+          expect(shopify_product.deep_stringify_keys).to include(expected_option_data.deep_stringify_keys)
+        end
+
         it 'does not extract product options when there are no options' do
           magento_product = FactoryBot.build(:magento_product)
           shopify_product = described_class.new.convert(magento_product, {})

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -92,27 +92,27 @@ module ShopifyTransporter::Pipeline::Magento::Product
           expect(shopify_product.deep_stringify_keys).to include(expected_option_data.deep_stringify_keys)
         end
 
-        it 'ignore the rest of options when there are more than three options' do
+        it 'ignores the rest of options when there are more than three options' do
           magento_product = FactoryBot.build(:magento_product)
           magento_product['option1_name'] = 'option1'
           magento_product['option2_name'] = 'option2'
           magento_product['option3_name'] = 'option3'
           magento_product['option4_name'] = 'option4'
           shopify_product = described_class.new.convert(magento_product, {})
-          expected_option_data = {
-            options: [
+          expected_option_data =
+            [
               {
-                'name': 'option1',
+                'name' => 'option1',
               },
               {
-                'name': 'option2',
+                'name' => 'option2',
               },
               {
-                'name': 'option3',
-              },
-            ],
-          }
-          expect(shopify_product.deep_stringify_keys).to include(expected_option_data.deep_stringify_keys)
+                'name' => 'option3',
+              }
+            ]
+
+          expect(shopify_product['options']).to eq(expected_option_data)
         end
 
         it 'does not extract product options when there are no options' do


### PR DESCRIPTION
### What it does and why:
For now, CLI will display warnings when the product has more than three options. Only the first 3 options will get converted.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

### Demo:
![screen shot 2018-09-28 at 3 24 32 pm](https://user-images.githubusercontent.com/21313470/46229247-f8844800-c332-11e8-9028-f68c08af0253.png)
<img width="577" alt="screen shot 2018-09-28 at 3 24 40 pm" src="https://user-images.githubusercontent.com/21313470/46229250-fae6a200-c332-11e8-880c-54149fcef0c0.png">

---

### Related issues:https://github.com/Shopify/transporter_app/issues/1278
Closes:
