### PR TITLE
Support variants with a single option

### DIFF
--- a/lib/shopify_transporter/exporters/magento/product_options.rb
+++ b/lib/shopify_transporter/exporters/magento/product_options.rb
@@ -26,6 +26,7 @@ module ShopifyTransporter
 
           parent_product_options = lowercase_option_names(simple_product[:parent_id])
           variant_attributes = simple_product[:additional_attributes][:item]
+          variant_attributes = [variant_attributes] unless variant_attributes.is_a?(Array)
           parent_product_options.each_with_index.with_object({}) do |(option_name, index), obj|
             option_value_id = fetch_option_value_id(option_name, variant_attributes)
 

--- a/spec/shopify_transporter/exporters/magento/product_options_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/product_options_spec.rb
@@ -147,8 +147,7 @@ module ShopifyTransporter
         end
 
         describe '#shopify_variant_options' do
-          it '#shopify_variant_options returns the option names and values from a given parent product' \
-            ' and attributes hash' do
+          it 'returns the option names and values from a given parent product and attributes hash' do
             simple_product = {
               parent_id: '402',
               additional_attributes: {
@@ -175,6 +174,24 @@ module ShopifyTransporter
                 'option1_value': 'White',
                 'option2_name': 'Size',
                 'option2_value': 'XS',
+              )
+          end
+
+          it 'works when the additional attributes item is a single object instead of an array' do
+            simple_product = {
+              parent_id: '403',
+              additional_attributes: {
+                item: {
+                  key: 'color',
+                  value: '22',
+                },
+              },
+            }
+
+            expect(product_options.shopify_variant_options(simple_product))
+              .to eq(
+                'option1_name': 'Color',
+                'option1_value': 'White'
               )
           end
 


### PR DESCRIPTION
### What it does and why:
- Support simple products which have a single option in the additional attributes array.

### Checklist:

- [X] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.