### PR TITLE
Rename export command to extract

### DIFF
--- a/exe/shopify_transporter
+++ b/exe/shopify_transporter
@@ -31,17 +31,17 @@ module ShopifyTransporter
     end
 
     method_option :config, type: :string, default: 'config.yml',
-      desc: 'The config file that describes the third party platform to export from.'
+      desc: 'The config file that describes the third party platform to extract from.'
     method_option :object, type: :string, required: true,
-      desc: 'The object type (customer, product, or order) to export.',
+      desc: 'The object type (customer, product, or order) to extract.',
       enum: %w(customer product order)
 
-    desc 'export', 'Exports objects from a third-party platform into a format compatible for conversion.'
-    def export
+    desc 'extract', 'Extracts objects from a third-party platform into a format compatible for conversion.'
+    def extract
       exporter = Exporters::Exporter.new(options[:config], options[:object])
       exporter.run
     rescue Exporters::ExportError => error
-      export_error(error.message)
+      extract_error(error.message)
     end
 
     no_commands do
@@ -50,8 +50,8 @@ module ShopifyTransporter
         exit 1
       end
 
-      def export_error(message)
-        say("Export error: #{message}", :red)
+      def extract_error(message)
+        say("Extract error: #{message}", :red)
         exit 1
       end
     end

--- a/lib/shopify_transporter/exporters/exporter.rb
+++ b/lib/shopify_transporter/exporters/exporter.rb
@@ -26,13 +26,13 @@ module ShopifyTransporter
       attr_reader :config, :object_type
 
       def print_exported_objects
-        $stderr.puts 'Starting export...'
+        $stderr.puts 'Starting extraction...'
         puts '['
         first = true
         object_exporter.export do |object|
           puts ',' unless first
           first = false
-          $stderr.puts "Fetching #{object_type}: #{object[object_exporter.key]}..."
+          $stderr.puts "Extracting #{object_type}: #{object[object_exporter.key]}..."
           print '  ' + JSON.pretty_generate(object, object_nl: "\n  ")
         end
       ensure
@@ -50,19 +50,19 @@ module ShopifyTransporter
 
       def soap_client
         Magento::Soap.new(
-          hostname: config['export_configuration']['soap']['hostname'],
-          username: config['export_configuration']['soap']['username'],
-          api_key: config['export_configuration']['soap']['api_key'],
+          hostname: config['extract_configuration']['soap']['hostname'],
+          username: config['extract_configuration']['soap']['username'],
+          api_key: config['extract_configuration']['soap']['api_key'],
         )
       end
 
       def database_adapter
         Magento::SQL.new(
-          database: config['export_configuration']['database']['database'],
-          host: config['export_configuration']['database']['host'],
-          user: config['export_configuration']['database']['user'],
-          port: config['export_configuration']['database']['port'],
-          password: config['export_configuration']['database']['password'],
+          database: config['extract_configuration']['database']['database'],
+          host: config['extract_configuration']['database']['host'],
+          user: config['extract_configuration']['database']['user'],
+          port: config['extract_configuration']['database']['port'],
+          password: config['extract_configuration']['database']['password'],
         )
       end
 
@@ -76,18 +76,18 @@ module ShopifyTransporter
 
       def ensure_config_has_required_keys
         base_required_keys = [
-          %w(export_configuration),
-          %w(export_configuration soap hostname),
-          %w(export_configuration soap username),
-          %w(export_configuration soap api_key),
+          %w(extract_configuration),
+          %w(extract_configuration soap hostname),
+          %w(extract_configuration soap username),
+          %w(extract_configuration soap api_key),
         ]
 
         product_required_keys = [
-          %w(export_configuration database host),
-          %w(export_configuration database port),
-          %w(export_configuration database database),
-          %w(export_configuration database user),
-          %w(export_configuration database password),
+          %w(extract_configuration database host),
+          %w(extract_configuration database port),
+          %w(extract_configuration database database),
+          %w(extract_configuration database user),
+          %w(extract_configuration database password),
         ]
 
         required_keys = base_required_keys + (@object_type == 'product' ? product_required_keys : [])

--- a/lib/templates/magento/config.tt
+++ b/lib/templates/magento/config.tt
@@ -29,7 +29,7 @@ object_types:
       - LineItems
       - AddressesAttribute
 
-export_configuration:
+extract_configuration:
   soap:
     hostname:
     username:

--- a/spec/shopify_transporter/exporters/exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/exporter_spec.rb
@@ -35,7 +35,7 @@ module ShopifyTransporter
               "pipeline_stages" => %w(TopLevelAttributes),
             },
           },
-          "export_configuration" => {
+          "extract_configuration" => {
             "soap" => {
               "hostname" => 'magento.host',
               "username" => 'something',
@@ -76,40 +76,40 @@ module ShopifyTransporter
       end
 
       it 'raises InvalidConfigError if config file is missing username' do
-        config_without_username = default_config.tap { |cfg| cfg['export_configuration']['soap'].delete('username') }
+        config_without_username = default_config.tap { |cfg| cfg['extract_configuration']['soap'].delete('username') }
         config_file = tmpfile(YAML.dump(config_without_username), '.yml')
 
-        error_message = "Invalid configuration: missing required key 'export_configuration > soap > username'"
+        error_message = "Invalid configuration: missing required key 'extract_configuration > soap > username'"
 
         expect { Exporter.new(config_file.path, :unused) }
           .to raise_error(InvalidConfigError, error_message)
       end
 
       it 'raises InvalidConfigError if config file is missing hostname' do
-        config_without_hostname = default_config.tap { |cfg| cfg['export_configuration']['soap'].delete('hostname') }
+        config_without_hostname = default_config.tap { |cfg| cfg['extract_configuration']['soap'].delete('hostname') }
         config_file = tmpfile(YAML.dump(config_without_hostname), '.yml')
 
-        error_message = "Invalid configuration: missing required key 'export_configuration > soap > hostname'"
+        error_message = "Invalid configuration: missing required key 'extract_configuration > soap > hostname'"
 
         expect { Exporter.new(config_file.path, :unused) }
           .to raise_error(InvalidConfigError, error_message)
       end
 
       it 'raises InvalidConfigError if config file is missing export configuration' do
-        config_without_export_configuration = default_config.tap { |cfg| cfg.delete('export_configuration') }
-        config_file = tmpfile(YAML.dump(config_without_export_configuration), '.yml')
+        config_without_extract_configuration = default_config.tap { |cfg| cfg.delete('extract_configuration') }
+        config_file = tmpfile(YAML.dump(config_without_extract_configuration), '.yml')
 
-        error_message = "Invalid configuration: missing required key 'export_configuration'"
+        error_message = "Invalid configuration: missing required key 'extract_configuration'"
 
         expect { Exporter.new(config_file.path, :unused) }
           .to raise_error(InvalidConfigError, error_message)
       end
 
       it 'raises InvalidConfigError if config file is missing api key' do
-        config = default_config.tap { |cfg| cfg['export_configuration']['soap'].delete('api_key') }
+        config = default_config.tap { |cfg| cfg['extract_configuration']['soap'].delete('api_key') }
         config_file = tmpfile(YAML.dump(config), '.yml')
 
-        error_message = "Invalid configuration: missing required key 'export_configuration > soap > api_key'"
+        error_message = "Invalid configuration: missing required key 'extract_configuration > soap > api_key'"
 
         expect { Exporter.new(config_file.path, :unused) }
           .to raise_error(InvalidConfigError, error_message)
@@ -118,20 +118,20 @@ module ShopifyTransporter
       context 'when processing database configuration' do
         %w(host port database user password).each do |key|
           it "for products, raises an InvalidConfigError if the database key #{key} is missing." do
-            config = default_config.tap { |cfg| cfg['export_configuration']['database'].delete(key) }
+            config = default_config.tap { |cfg| cfg['extract_configuration']['database'].delete(key) }
             config_file = tmpfile(YAML.dump(config), '.yml')
 
-            error_message = "Invalid configuration: missing required key 'export_configuration > database > #{key}'"
+            error_message = "Invalid configuration: missing required key 'extract_configuration > database > #{key}'"
 
             expect { Exporter.new(config_file.path, 'product') }
               .to raise_error(InvalidConfigError, error_message)
           end
 
           it "for non-product objects, does not raise an InvalidConfigError if the database key #{key} is missing." do
-            config = default_config.tap { |cfg| cfg['export_configuration']['database'].delete(key) }
+            config = default_config.tap { |cfg| cfg['extract_configuration']['database'].delete(key) }
             config_file = tmpfile(YAML.dump(config), '.yml')
 
-            error_message = "Invalid configuration: missing required key 'export_configuration > database > #{key}'"
+            error_message = "Invalid configuration: missing required key 'extract_configuration > database > #{key}'"
 
             expect { Exporter.new(config_file.path, 'other_object') }.not_to raise_error
           end


### PR DESCRIPTION
### What it does and why:
- Renames the export command to extract because this is more appropriate.

### Checklist:

- [X] Testing & QA: Passes tests and linting.
- [X] :tophat:: I have manually tested these changes.