### PR TITLE
Retry soap calls up to 5 times

### DIFF
--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -72,6 +72,30 @@ module ShopifyTransporter
 
             Soap.new(init_params).call(:test_call, {})
           end
+
+          it 'retries soap calls up to 4 times with a delay when there is a savon error' do
+            mock_client = spy('mock_client')
+            stub_client_call(mock_client)
+            stub_login_call(mock_client)
+
+            soap_instance = Soap.new(init_params)
+
+            attempt = 0
+            expect(mock_client).to receive(:call).with(
+              :test_call,
+              message: {
+                session_id: '123',
+              },
+            ) do |args|
+              attempt += 1
+              if attempt < 5
+                expect(soap_instance).to receive(:sleep).with(described_class::RETRY_SLEEP_TIME * attempt)
+                raise Savon::Error, 'Soap call failed.'
+              end
+            end.exactly(described_class::MAX_RETRIES + 1).times
+
+            soap_instance.call(:test_call, {})
+          end
         end
 
         describe '#call_in_batches' do


### PR DESCRIPTION
### What it does and why:
- Retries soap calls up to 5 times to get past flaky responses and errors.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.
