### PR TITLE
Handle the situation where SOAP calls return objects instead of arrays for singular responses.

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -94,6 +94,7 @@ module ShopifyTransporter
             end
 
             def product_tags(input)
+              return input['tags']['name'] if input['tags'].is_a?(Hash)
               input['tags'].map { |tag| tag['name'] }.join(', ')
             end
           end

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -56,13 +56,18 @@ module ShopifyTransporter
               input['visibility'].present? && input['visibility'].to_i != 1
             end
 
+            def apply_image_column_mapping(input_image)
+              {
+                'src' => input_image['url'],
+                'position' => input_image['position'],
+                'alt' => image_alt_text(input_image['label']),
+              }
+            end
+
             def construct_images(input)
+              return [apply_image_column_mapping(input['images'])] if input['images'].is_a?(Hash)
               images = input['images'].map do |image|
-                {
-                  'src' => image['url'],
-                  'position' => image['position'],
-                  'alt' => image_alt_text(image['label']),
-                }.compact
+                apply_image_column_mapping(image).compact
               end
               images.sort_by { |image| image['position'] }
             end

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -63,6 +63,15 @@ FactoryBot.define do
       end
     end
 
+    trait :with_singular_tag do
+      tags do
+        {
+          "tag_id": "19",
+          "name": "grey"
+        }
+      end
+    end
+
     trait :with_product_options do
       option1_name 'Color'
       option2_name 'Size'

--- a/spec/factories/magento/product.rb
+++ b/spec/factories/magento/product.rb
@@ -35,6 +35,16 @@ FactoryBot.define do
         ]
       end
     end
+    trait :with_singular_image do
+      images do
+        {
+          "file": "/c/s/csv.png",
+          "position": 1,
+          "url": "https://magento-sandbox.myshopify.io/media/catalog/product/c/s/csv.png",
+          "label": 'alt_text'
+        }
+      end
+    end
 
     trait :with_product_tags do
       tags do

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -157,6 +157,21 @@ module ShopifyTransporter::Pipeline::Magento::Product
           expect(shopify_product.deep_stringify_keys).to include(expected_shopify_product_image.deep_stringify_keys)
         end
 
+        it 'should handle product with only one image' do
+          magento_product = FactoryBot.build(:magento_product, :with_singular_image)
+          shopify_product = described_class.new.convert(magento_product, {})
+          expected_shopify_product_image =
+            [
+              {
+                src: 'https://magento-sandbox.myshopify.io/media/catalog/product/c/s/csv.png',
+                position: 1,
+                alt: 'alt_text',
+              }.deep_stringify_keys
+            ]
+
+          expect(shopify_product['images']).to eq(expected_shopify_product_image)
+        end
+
         it 'Merge the parent image with the existing image arrays if child products get processed before parent product does' do
           record = {
             'images' => [

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -52,6 +52,15 @@ module ShopifyTransporter::Pipeline::Magento::Product
         expect(shopify_product.deep_stringify_keys).to include(expected_product_tag_info.deep_stringify_keys)
       end
 
+      it 'should handle product with only one tag' do
+        magento_product = FactoryBot.build(:magento_product, :with_singular_tag)
+        shopify_product = described_class.new.convert(magento_product, {})
+        expected_product_tag_info = {
+          tags: 'grey'
+        }
+        expect(shopify_product.deep_stringify_keys).to include(expected_product_tag_info.deep_stringify_keys)
+      end
+
       describe 'product options' do
         it 'extracts product options when there are three options' do
           magento_product = FactoryBot.build(:magento_product, :with_product_options)


### PR DESCRIPTION
### What it does and why:
- Handle product conversion with one top-level image
- Handle product conversion with one tag

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues: https://github.com/Shopify/transporter_app/issues/1345
Closes:
