### PR TITLE
Reject JSON input with unexpected format during conversion step

### DIFF
--- a/lib/shopify_transporter.rb
+++ b/lib/shopify_transporter.rb
@@ -121,7 +121,7 @@ class TransporterTool
     file_data = File.read(file_name)
     parsed_file_data = Yajl::Parser.parse(file_data)
     return if parsed_file_data.nil? || parsed_file_data.empty?
-    raise UnexpectedJSONStructureError unless expected_json_structure(parsed_file_data)
+    raise UnexpectedJSONStructureError unless expected_json_structure?(parsed_file_data)
     record = 1
 
     parsed_file_data.each do |json_row|
@@ -262,7 +262,7 @@ class TransporterTool
     @config['object_types'][@object_type]['key_required']
   end
 
-  def expected_json_structure(input)
+  def expected_json_structure?(input)
     input.is_a?(Array) && input.all? { |json_row| json_row.is_a?(Hash) }
   end
 end

--- a/lib/shopify_transporter.rb
+++ b/lib/shopify_transporter.rb
@@ -46,7 +46,7 @@ class TransporterTool
   class UnexpectedJSONStructureError < ConversionError
     def initialize
       super(
-        'Unexpected JSON structure detected. It must be an array of JSONs.'
+        'Unexpected JSON structure detected. The expected format is an array of JSON objects: [{}, {}]'
       )
     end
   end
@@ -263,7 +263,7 @@ class TransporterTool
   end
 
   def raise_if_unexpected_json_structure(input)
-    is_in_expected_format = input.is_a?(Array) ? input.all? { |json_row| json_row.is_a?(Hash) } : false
+    is_in_expected_format = input.is_a?(Array) && input.all? { |json_row| json_row.is_a?(Hash) }
     raise UnexpectedJSONStructureError unless is_in_expected_format
   end
 end

--- a/lib/shopify_transporter.rb
+++ b/lib/shopify_transporter.rb
@@ -121,7 +121,7 @@ class TransporterTool
     file_data = File.read(file_name)
     parsed_file_data = Yajl::Parser.parse(file_data)
     return if parsed_file_data.nil? || parsed_file_data.empty?
-    raise_if_unexpected_json_structure(parsed_file_data)
+    raise UnexpectedJSONStructureError unless expected_json_structure(parsed_file_data)
     record = 1
 
     parsed_file_data.each do |json_row|
@@ -262,8 +262,7 @@ class TransporterTool
     @config['object_types'][@object_type]['key_required']
   end
 
-  def raise_if_unexpected_json_structure(input)
-    is_in_expected_format = input.is_a?(Array) && input.all? { |json_row| json_row.is_a?(Hash) }
-    raise UnexpectedJSONStructureError unless is_in_expected_format
+  def expected_json_structure(input)
+    input.is_a?(Array) && input.all? { |json_row| json_row.is_a?(Hash) }
   end
 end

--- a/lib/shopify_transporter.rb
+++ b/lib/shopify_transporter.rb
@@ -46,7 +46,7 @@ class TransporterTool
   class UnexpectedJSONStructureError < ConversionError
     def initialize
       super(
-        'Unexpected JSON structure detected. The expected format is an array of JSON objects: [{}, {}]'
+        'Unexpected JSON structure detected. The expected format is an array of JSON objects: [{}, {}, ..., {}]'
       )
     end
   end

--- a/lib/shopify_transporter.rb
+++ b/lib/shopify_transporter.rb
@@ -46,7 +46,7 @@ class TransporterTool
   class UnexpectedJSONStructureError < ConversionError
     def initialize
       super(
-        "Unexpected JSON structure detected. It must be an array of JSONs."
+        'Unexpected JSON structure detected. It must be an array of JSONs.'
       )
     end
   end
@@ -121,7 +121,7 @@ class TransporterTool
     file_data = File.read(file_name)
     parsed_file_data = Yajl::Parser.parse(file_data)
     return if parsed_file_data.nil? || parsed_file_data.empty?
-    raise_if_unexpected_JSON_structure(parsed_file_data)
+    raise_if_unexpected_json_structure(parsed_file_data)
     record = 1
 
     parsed_file_data.each do |json_row|
@@ -262,7 +262,7 @@ class TransporterTool
     @config['object_types'][@object_type]['key_required']
   end
 
-  def raise_if_unexpected_JSON_structure(input)
+  def raise_if_unexpected_json_structure(input)
     is_in_expected_format = input.is_a?(Array) ? input.all? { |json_row| json_row.is_a?(Hash) } : false
     raise UnexpectedJSONStructureError unless is_in_expected_format
   end

--- a/spec/shopify_transporter/shopify_transporter_spec.rb
+++ b/spec/shopify_transporter/shopify_transporter_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe ShopifyTransporter do
       config = 'spec/files/config.yml'
       @tool = TransporterTool.new(*[file.path], config, 'customer')
       expect{ @tool.run }.to raise_error(TransporterTool::UnexpectedJSONStructureError,
-        'Unexpected JSON structure detected. The expected format is an array of JSON objects: [{}, {}]')
+        'Unexpected JSON structure detected. The expected format is an array of JSON objects: [{}, {}, ..., {}]')
     end
   end
 

--- a/spec/shopify_transporter/shopify_transporter_spec.rb
+++ b/spec/shopify_transporter/shopify_transporter_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe ShopifyTransporter do
       config = 'spec/files/config.yml'
       @tool = TransporterTool.new(*[file.path], config, 'customer')
       expect{ @tool.run }.to raise_error(TransporterTool::UnexpectedJSONStructureError,
-        'Unexpected JSON structure detected. It must be an array of JSONs.')
+        'Unexpected JSON structure detected. The expected format is an array of JSON objects: [{}, {}]')
     end
   end
 

--- a/spec/shopify_transporter/shopify_transporter_spec.rb
+++ b/spec/shopify_transporter/shopify_transporter_spec.rb
@@ -271,6 +271,19 @@ RSpec.describe ShopifyTransporter do
       expect(errors[0]).to match(/2, .*field not found/)
       expect(stdout.split($/).count).to be > 1
     end
+
+    it 'rejects JSON with unexpected structure' do
+      content = {
+        increment_id: "increment_id-value"
+      }.to_json
+      file = Tempfile.new(['bad_json', '.json'])
+      file.puts content
+      file.close
+      config = 'spec/files/config.yml'
+      @tool = TransporterTool.new(*[file.path], config, 'customer')
+      expect{ @tool.run }.to raise_error(TransporterTool::UnexpectedJSONStructureError,
+        'Unexpected JSON structure detected. It must be an array of JSONs.')
+    end
   end
 
   describe ShopifyTransporter::New do


### PR DESCRIPTION
### What it does and why:
Small fix to reject json input with unexpected format during conversion step. See https://github.com/Shopify/shopify_transporter/issues/9 for the context.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues: https://github.com/Shopify/shopify_transporter/issues/9
Closes:
