### PR TITLE
[WIP] Skip batches if there are errors

### DIFF
--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -33,10 +33,14 @@ module ShopifyTransporter
 
               $stderr.puts "Processing batch: #{current_id}..#{end_of_range}"
 
-              enumerator << call(
-                method,
-                params.merge(batching_filter(current_id, end_of_range, batch_index_column)),
-              )
+              begin
+                enumerator << call(
+                  method,
+                  params.merge(batching_filter(current_id, end_of_range, batch_index_column)),
+                )
+              rescue Savon::Error
+                $stderr.puts "Skipping batch: #{current_id}..#{end_of_range} after #{MAX_RETRIES} retries because of an error."
+              end
 
               current_id += batch_size
             end


### PR DESCRIPTION
### What it does and why:
- Skips batches that raise errors after 5 retries.

### Checklist:

- [ ] Testing & QA: Passes tests and linting.
- [ ] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/67
