### PR TITLE
Trap program termination so we don't output a stack trace

### DIFF
--- a/exe/shopify_transporter
+++ b/exe/shopify_transporter
@@ -52,6 +52,8 @@ module ShopifyTransporter
       exporter.run
     rescue Exporters::ExportError => error
       extract_error(error.message)
+    rescue SystemExit, Interrupt
+      $stderr.puts "\n...exiting"
     end
 
     no_commands do


### PR DESCRIPTION
### What it does and why:
- Trap program termination
-  So we don't output a stack trace
### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Before:
![image](https://user-images.githubusercontent.com/22937651/46484958-c9555700-c7c8-11e8-9c9f-90bb4e0c4606.png)

### After:
![image](https://user-images.githubusercontent.com/22937651/46484901-b04ca600-c7c8-11e8-9fd8-b252a42456e2.png)

