### PR TITLE
 return empty cell instead of empty string when published_at is not present

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -49,7 +49,7 @@ module ShopifyTransporter
               append_images_to_current_record!(input) if input['images'].present?
               attributes['tags'] = product_tags(input) if input['tags'].present?
               attributes['options'] = product_options(input) if input['option1_name'].present?
-              attributes
+              attributes.compact
             end
 
             def published?(input)

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -45,11 +45,11 @@ module ShopifyTransporter
               attributes = map_from_key_to_val(COLUMN_MAPPING, input)
               attributes['published'] = published?(input)
               attributes['published_scope'] = published?(input) ? 'global' : ''
-              attributes['published_at'] = published?(input) ? input['updated_at'] : nil
+              attributes['published_at'] = input['updated_at'] if published?(input)
               append_images_to_current_record!(input) if input['images'].present?
               attributes['tags'] = product_tags(input) if input['tags'].present?
               attributes['options'] = product_options(input) if input['option1_name'].present?
-              attributes.compact
+              attributes
             end
 
             def published?(input)

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_attributes.rb
@@ -45,7 +45,7 @@ module ShopifyTransporter
               attributes = map_from_key_to_val(COLUMN_MAPPING, input)
               attributes['published'] = published?(input)
               attributes['published_scope'] = published?(input) ? 'global' : ''
-              attributes['published_at'] = published?(input) ? input['updated_at'] : ''
+              attributes['published_at'] = published?(input) ? input['updated_at'] : nil
               append_images_to_current_record!(input) if input['images'].present?
               attributes['tags'] = product_tags(input) if input['tags'].present?
               attributes['options'] = product_options(input) if input['option1_name'].present?

--- a/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/product/top_level_attributes_spec.rb
@@ -13,7 +13,6 @@ module ShopifyTransporter::Pipeline::Magento::Product
           body_html: magento_product['description'],
           handle: magento_product['url_key'],
           published: false,
-          published_at: '',
           published_scope: '',
         }
 


### PR DESCRIPTION
### What it does and why:

If we pass `""` as a published at date to the Transporter app, it fails. So we should just.. not do that.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
