### PR TITLE
Skip an object if subsequent api calls fail for that object

### DIFF
--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,9 +1,8 @@
-# Recommended rubocop version: ~> 0.56.0
-
 AllCops:
   Exclude:
   - 'db/schema.rb'
   DisabledByDefault: true
+  StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -33,10 +33,17 @@ module ShopifyTransporter
 
               $stderr.puts "Processing batch: #{current_id}..#{end_of_range}"
 
-              enumerator << call(
-                method,
-                params.merge(batching_filter(current_id, end_of_range, batch_index_column)),
-              )
+              begin
+                enumerator << call(
+                  method,
+                  params.merge(batching_filter(current_id, end_of_range, batch_index_column)),
+                )
+              rescue Savon::Error => e
+                $stderr.puts "Skipping batch: #{current_id}..#{end_of_range} after #{MAX_RETRIES} retries because of an error."
+                $stderr.puts 'The exact error was:'
+                $stderr.puts "#{e.class}: "
+                $stderr.puts e.message
+              end
 
               current_id += batch_size
             end

--- a/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/order_exporter_spec.rb
@@ -136,6 +136,78 @@ module ShopifyTransporter
             exporter = described_class.new(soap_client: soap_client)
             expect { |block| exporter.export(&block) }.to yield_successive_args(*expected_result)
           end
+
+          context 'when order details are unretrievable' do
+            it 'skips the current order' do
+              soap_client = double('soap client')
+
+              sales_order_list_response_body = double('sales_order_list_response_body')
+              sales_order_info_response_body = double('sales_order_info_response_body')
+              expect(soap_client)
+                .to receive(:call_in_batches)
+                .with(
+                  method: :sales_order_list,
+                  batch_index_column: 'order_id',
+                )
+                .and_return([sales_order_list_response_body])
+                .at_least(:once)
+
+              expect(sales_order_list_response_body).to receive(:body).and_return(
+                sales_order_list_response: {
+                  result: {
+                    item: [
+                      {
+                        increment_id: '10',
+                        order_id: '10',
+                        top_level_attribute: 'order1',
+                      },
+                    ]
+                  },
+                },
+              ).at_least(:once)
+
+              expect(soap_client)
+                .to receive(:call).with(:sales_order_info, order_increment_id: '10')
+                .and_raise(Savon::Error)
+
+              allow(sales_order_info_response_body).to receive(:body).and_return(
+                sales_order_info_response: {
+                  result: {
+                    order_info_attribute: 'info',
+                  },
+                },
+              )
+
+              expected_result = {
+                increment_id: '10',
+                order_id: '10',
+                top_level_attribute: 'order1',
+              }
+
+              exporter = described_class.new(soap_client: soap_client)
+              expect do |block|
+                stderr = capture(:stderr) { exporter.export(&block) }
+                output = <<~WARNING
+                  ***
+                  Warning:
+                  Encountered an error with fetching details for order with id: 10
+                  {
+                    "increment_id": "10",
+                    "order_id": "10",
+                    "top_level_attribute": "order1"
+                  }
+                  The exact error was:
+                  Savon::Error: 
+                  Savon::Error
+                  -
+                  Exporting the order (10) without its details.
+                  Continuing with the next order.
+                  ***
+                WARNING
+                expect(stderr).to eq(output)
+              end.to yield_with_args(expected_result)
+            end
+          end
         end
       end
     end

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -212,9 +212,20 @@ module ShopifyTransporter
               raise Savon::Error, 'Soap call failed.'
             end
 
-
-            expect { |b| soap_client.call_in_batches(method: :test_call, batch_index_column: 'customer_id').each(&b) }
-              .to yield_successive_args(['batch-0,1,2'], ['batch-6,7'])
+            stderr = nil
+            expect do |b|
+              stderr = capture(:stderr) { soap_client.call_in_batches(method: :test_call, batch_index_column: 'customer_id').each(&b) }
+            end.to yield_successive_args(['batch-0,1,2'], ['batch-6,7'])
+            output = <<~WARNING
+              Processing batch: 0..2
+              Processing batch: 3..5
+              Skipping batch: 3..5 after 4 retries because of an error.
+              The exact error was:
+              Savon::Error: 
+              Soap call failed.
+              Processing batch: 6..7
+            WARNING
+            expect(stderr).to eq(output)
           end
         end
       end


### PR DESCRIPTION
### What it does and why:
- When building an object requires multiple requests, fail and move onto the next object if any of the calls happen to fail. Log this to stderr to let the user know.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/68, https://github.com/Shopify/shopify_transporter/issues/67
