### PR TITLE
Fix order tax rate bug

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/order/line_items.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/line_items.rb
@@ -47,9 +47,13 @@ module ShopifyTransporter
               {
                 title: 'Tax',
                 price: item['tax_amount'],
-                rate: item['tax_percent'],
+                rate: tax_percentage(item),
               }.stringify_keys,
             ]
+          end
+
+          def tax_percentage(item)
+            item['tax_percent'].to_f / 100
           end
 
           def tax_applied?(item)

--- a/spec/shopify_transporter/pipeline/magento/order/line_items_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/order/line_items_spec.rb
@@ -46,7 +46,7 @@ module ShopifyTransporter::Pipeline::Magento::Order
               {
                 title: 'Tax',
                 price: "10",
-                rate: "12",
+                rate: 0.12,
               }
             ]
           }.deep_stringify_keys


### PR DESCRIPTION
### What it does and why:
see https://github.com/Shopify/shopify_transporter/issues/81
The tax rate should be divided by 100 during conversion.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues: https://github.com/Shopify/shopify_transporter/issues/81
Closes:
