### PR TITLE
Fix a bug where child product in order CSV will occupy two lines as their parent product shows up too

### DIFF
--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'pry'
+
 module ShopifyTransporter
   module Exporters
     module Magento


### PR DESCRIPTION
### What it does and why:
see https://github.com/Shopify/shopify_transporter/issues/91

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.


### Demo:
#### Before:
![screen shot 2018-10-17 at 9 44 59 am](https://user-images.githubusercontent.com/21313470/47090861-c0657c00-d1f1-11e8-8cb2-0cc2dd725e2d.png)

#### After:

![screen shot 2018-10-17 at 9 47 17 am](https://user-images.githubusercontent.com/21313470/47090866-c3606c80-d1f1-11e8-9c7d-8a473dc0d0b0.png)


---

### Related issues: https://github.com/Shopify/shopify_transporter/issues/91
Closes:
