### PR TITLE
refactor #92 to work without mutation

### DIFF
--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'pry'
+
 module ShopifyTransporter
   module Exporters
     module Magento

--- a/lib/shopify_transporter/exporters/magento/order_exporter.rb
+++ b/lib/shopify_transporter/exporters/magento/order_exporter.rb
@@ -55,14 +55,14 @@ module ShopifyTransporter
           {
             result: {
               items: {
-                item: remove_child_items(products)
-              }
-            }
+                item: remove_children(products),
+              },
+            },
           }
         end
 
-        def remove_child_items(products)
-          products.group_by { |product| product[:sku] }.map do |sku, related_products|
+        def remove_children(products)
+          products.group_by { |product| product[:sku] }.map do |_sku, related_products|
             parent_with_child_name(related_products)
           end
         end


### PR DESCRIPTION
### What it does and why:

this is a possible alternate way to approach https://github.com/Shopify/shopify_transporter/pull/92 that (IMO) is more ruby-ic

### Demo

Before:
<img width="691" alt="screen shot 2018-10-17 at 9 40 15 am" src="https://user-images.githubusercontent.com/21313470/47090328-b55e1c00-d1f0-11e8-8336-52d352498554.png">
After:
<img width="688" alt="screen shot 2018-10-17 at 9 39 51 am" src="https://user-images.githubusercontent.com/21313470/47090336-b98a3980-d1f0-11e8-8868-480b4f01e8ff.png">

^ demo images courtesy of Ziyan

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [ ] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
https://github.com/Shopify/shopify_transporter/issues/91