### PR TITLE
Fix default address bug

### DIFF
--- a/lib/shopify_transporter/shopify/customer.rb
+++ b/lib/shopify_transporter/shopify/customer.rb
@@ -2,7 +2,7 @@
 require_relative 'record'
 require 'active_support/inflector'
 require 'csv'
-require 'pry'
+
 module ShopifyTransporter
   module Shopify
     class Customer < Record

--- a/lib/shopify_transporter/shopify/customer.rb
+++ b/lib/shopify_transporter/shopify/customer.rb
@@ -67,19 +67,17 @@ module ShopifyTransporter
       end
 
       def default_address
-        if at_least_one_address?
-          record_hash['addresses'][0].slice(*ADDRESS_ATTRIBUTES)
-        else
-          {}
-        end
+        return {} unless at_least_one_address?
+
+        record_hash['addresses'][0].slice(*ADDRESS_ATTRIBUTES)
       end
 
       def at_least_one_address?
-        record_hash.dig('addresses').present? && record_hash.dig('addresses')[0].present?
+        record_hash['addresses'].present? && record_hash['addresses'][0].present?
       end
 
       def address_row_values
-        return [] unless record_hash['addresses'].present?
+        return [] unless record_hash['addresses'].present? && record_hash['addresses'].length > 1
         record_hash['addresses'].drop(1).map do |address_hash|
           address = address_hash.slice(*ADDRESS_ATTRIBUTES)
           populate_missing_address_attributes!(address)

--- a/lib/shopify_transporter/shopify/customer.rb
+++ b/lib/shopify_transporter/shopify/customer.rb
@@ -57,7 +57,7 @@ module ShopifyTransporter
       ).freeze
 
       def top_level_row_values
-        return top_level_attributes.values if not_able_to_merge_address?
+        return top_level_attributes.values unless able_to_merge_address?
 
         top_level_attributes.merge(default_address.compact).values_at(*Customer.columns)
       end
@@ -76,8 +76,8 @@ module ShopifyTransporter
         record_hash['addresses'].present? && record_hash['addresses'][0].present?
       end
 
-      def not_able_to_merge_address?
-        top_level_attributes.compact.keys.any? do |key|
+      def able_to_merge_address?
+        !top_level_attributes.compact.keys.any? do |key|
           default_address[key].present? && top_level_attributes[key] != default_address[key]
         end
       end
@@ -85,7 +85,7 @@ module ShopifyTransporter
       def address_row_values
         return [] unless at_least_one_address?
 
-        addresses = not_able_to_merge_address? ? record_hash['addresses'] : record_hash['addresses'].drop(1)
+        addresses = able_to_merge_address? ? record_hash['addresses'].drop(1) : record_hash['addresses']
         addresses.map do |address_hash|
           address = address_hash.slice(*ADDRESS_ATTRIBUTES)
           populate_missing_address_attributes!(address)

--- a/lib/shopify_transporter/shopify/customer.rb
+++ b/lib/shopify_transporter/shopify/customer.rb
@@ -57,7 +57,7 @@ module ShopifyTransporter
       ).freeze
 
       def top_level_row_values
-        return top_level_attributes.values unless able_to_merge_address?
+        return top_level_attributes.values unless able_to_merge_default_address?
 
         top_level_attributes.merge(default_address.compact).values_at(*Customer.columns)
       end
@@ -76,7 +76,7 @@ module ShopifyTransporter
         record_hash['addresses'].present? && record_hash['addresses'][0].present?
       end
 
-      def able_to_merge_address?
+      def able_to_merge_default_address?
         !top_level_attributes.compact.keys.any? do |key|
           default_address[key].present? && top_level_attributes[key] != default_address[key]
         end
@@ -85,7 +85,7 @@ module ShopifyTransporter
       def address_row_values
         return [] unless at_least_one_address?
 
-        addresses = able_to_merge_address? ? record_hash['addresses'].drop(1) : record_hash['addresses']
+        addresses = able_to_merge_default_address? ? record_hash['addresses'].drop(1) : record_hash['addresses']
         addresses.map do |address_hash|
           address = address_hash.slice(*ADDRESS_ATTRIBUTES)
           populate_missing_address_attributes!(address)

--- a/lib/shopify_transporter/shopify/customer.rb
+++ b/lib/shopify_transporter/shopify/customer.rb
@@ -76,8 +76,12 @@ module ShopifyTransporter
         record_hash['addresses'].present? && record_hash['addresses'][0].present?
       end
 
+      def more_than_one_address?
+        record_hash['addresses'].present? && record_hash['addresses'].length > 1
+      end
+
       def address_row_values
-        return [] unless record_hash['addresses'].present? && record_hash['addresses'].length > 1
+        return [] unless more_than_one_address?
         record_hash['addresses'].drop(1).map do |address_hash|
           address = address_hash.slice(*ADDRESS_ATTRIBUTES)
           populate_missing_address_attributes!(address)

--- a/spec/shopify_transporter/shopify/customer_spec.rb
+++ b/spec/shopify_transporter/shopify/customer_spec.rb
@@ -67,7 +67,7 @@ module ShopifyTransporter
           )
         end
 
-        it 'produces rows with overridden last_name/first_name/phone those values exist in the address' do
+        it 'produces rows with overridden last_name/first_name/phone if those values exist in the address' do
           hash = FactoryBot.build(
               :shopify_customer_hash,
               addresses:  [

--- a/spec/shopify_transporter/shopify/customer_spec.rb
+++ b/spec/shopify_transporter/shopify/customer_spec.rb
@@ -115,7 +115,7 @@ module ShopifyTransporter
       end
 
       def top_level_attributes_row(hash)
-        if addresses?(hash) && !not_able_to_merge_address?(hash)
+        if addresses?(hash) && able_to_merge_address?(hash)
             [
               *hash.values_at(*top_level_attributes),
               *hash['addresses'][0].values_at(*address_attributes),
@@ -152,11 +152,11 @@ module ShopifyTransporter
       end
 
 
-      def not_able_to_merge_address?(hash)
+      def able_to_merge_address?(hash)
         default_address = hash['addresses'].present? ? hash['addresses'][0] : {}
         top_level_attribute_hash = hash.slice(*top_level_attributes).compact
 
-        top_level_attribute_hash.keys.any? do |key|
+        !top_level_attribute_hash.keys.any? do |key|
           default_address[key].present? && top_level_attribute_hash[key] != default_address[key]
         end
       end

--- a/spec/shopify_transporter/shopify/customer_spec.rb
+++ b/spec/shopify_transporter/shopify/customer_spec.rb
@@ -115,7 +115,7 @@ module ShopifyTransporter
       end
 
       def top_level_attributes_row(hash)
-        if addresses?(hash) && able_to_merge_address?(hash)
+        if addresses?(hash) && able_to_merge_default_address?(hash)
             [
               *hash.values_at(*top_level_attributes),
               *hash['addresses'][0].values_at(*address_attributes),
@@ -152,7 +152,7 @@ module ShopifyTransporter
       end
 
 
-      def able_to_merge_address?(hash)
+      def able_to_merge_default_address?(hash)
         default_address = hash['addresses'].present? ? hash['addresses'][0] : {}
         top_level_attribute_hash = hash.slice(*top_level_attributes).compact
 


### PR DESCRIPTION
### What it does and why:
See https://github.com/Shopify/transporter_app/issues/1346

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

### Demo:

#### if the top level attributes also exist in default address and they are the same , merge the default address into the top level row:

##### On master:
<img width="1138" alt="screen shot 2018-10-26 at 11 57 28 am" src="https://user-images.githubusercontent.com/21313470/47578046-601fba00-d916-11e8-8243-3850d27b623d.png">

#### On this branch:
<img width="1196" alt="screen shot 2018-10-26 at 11 57 38 am" src="https://user-images.githubusercontent.com/21313470/47578057-6ada4f00-d916-11e8-8b91-2e8f41d3328a.png">

#### if any of the `first_name`, `last_name` and `phone` exists but is different in top level attributes and default address, don't bother merging:

##### On master && On this branch:
<img width="1338" alt="screen shot 2018-10-26 at 1 00 27 pm" src="https://user-images.githubusercontent.com/21313470/47581354-269f7c80-d91f-11e8-991c-ebbfd96f9a80.png">




---

### Related issues: https://github.com/Shopify/transporter_app/issues/1346
Closes:
