### PR TITLE
fix duplicate line item issue

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/order/line_items.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/line_items.rb
@@ -23,7 +23,7 @@ module ShopifyTransporter
           end
 
           def combine_associated_line_items(line_items)
-            line_items.group_by { |line_item| line_item['sku'] }.map do |sku, associated_items|
+            line_items.group_by { |line_item| line_item['sku'] }.map do |_, associated_items|
               case associated_items.size
               when 1
                 associated_items.first

--- a/lib/shopify_transporter/pipeline/magento/order/line_items.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/line_items.rb
@@ -23,7 +23,7 @@ module ShopifyTransporter
           end
 
           def combine_associated_line_items(line_items)
-            line_items.group_by { |y| y['sku'] }.map do |sku, associated_items|
+            line_items.group_by { |line_item| line_item['sku'] }.map do |sku, associated_items|
               case associated_items.size
               when 1
                 associated_items.first

--- a/spec/factories/magento/order.rb
+++ b/spec/factories/magento/order.rb
@@ -219,6 +219,7 @@ FactoryBot.define do
     sequence(:price) { |n| "price-#{n}" }
     sequence(:tax_amount) { |n| "tax_amount-#{n}" }
     sequence(:tax_percent) { |n| "tax_percent-#{n}" }
+    product_type 'simple'
 
     initialize_with { attributes.stringify_keys }
   end


### PR DESCRIPTION
### What it does and why:

same thing as #92 and #93 were intended to do, but we decided it makes more sense to do it in the conversion phase

### Demo:

Behaviour on master:

```
100000051,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Chelsea Tee,6.0000,75.0000,mtk004,true,false,,,,,,,,,,,,,,,,,,,,
100000051,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Chelsea Tee,6.0000,0.0000,mtk004,true,false,,,,,,,,,,,,,,,,,,,,
100000051,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Elizabeth Knit Top,1.0000,210.0000,wbk012,true,false,,,,,,,,,,,,,,,,,,,,
100000051,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Elizabeth Knit Top,1.0000,0.0000,wbk012,true,false,,,,,,,,,,,,,,,,,,,,
```

![image](https://user-images.githubusercontent.com/7587265/47513981-6007b780-d84d-11e8-9c27-df6a8f812b48.png)


Behaviour on this branch:

```
100000051,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Chelsea Tee,6.0000,75.0000,mtk004,true,false,,,,,,,,,,,,,,,,,,,,
100000051,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,Elizabeth Knit Top,1.0000,210.0000,wbk012,true,false,,,,,,,,,,,,,,,,,,,,
```

![image](https://user-images.githubusercontent.com/7587265/47513958-53835f00-d84d-11e8-8870-24f0c91a1772.png)


### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
https://github.com/Shopify/shopify_transporter/issues/91