### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/lib/shopify_transporter/version.rb
+++ b/lib/shopify_transporter/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyTransporter
-  VERSION = '2.3.1'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
### What it does and why:
- Bumps gem version to 2.4.0 to release recent additions and fixes.
