### PR TITLE
Add more detailed error messaging for login failures

### DIFF
--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'savon'
-require 'pry'
 
 module ShopifyTransporter
   module Exporters

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -90,9 +90,10 @@ module ShopifyTransporter
             }
           ).body
 
-          raise FailedLoginError, result.to_s unless result&.dig(:login_response, :login_return).present?
+          session_id = result&.dig(:login_response, :login_return)
+          raise FailedLoginError, result.to_s unless session_id.present?
 
-          @soap_session_id ||= result.dig(:login_response, :login_return)
+          @soap_session_id ||= session_id
         end
 
         def batching_filter(starting_id, ending_id, batch_index_column)

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -10,7 +10,7 @@ module ShopifyTransporter
         class FailedLoginError < Exporters::ExportError
           def initialize(error_message)
             sep = $INPUT_RECORD_SEPARATOR
-            super("Unable to obtain SOAP session ID from server.#{sep + sep}Details:#{sep + sep + error_message}")
+            super("Unable to obtain SOAP session ID from server.#{sep + sep}Details:#{sep + error_message}")
           end
         end
 

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -9,7 +9,8 @@ module ShopifyTransporter
       class Soap
         class FailedLoginError < Exporters::ExportError
           def initialize(error_message)
-            super("Unable to obtain SOAP session ID from server.#{$/ + $/}Details:#{$/ + $/ + error_message}")
+            sep = $INPUT_RECORD_SEPARATOR
+            super("Unable to obtain SOAP session ID from server.#{sep + sep}Details:#{sep + sep + error_message}")
           end
         end
 

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -49,9 +49,9 @@ module ShopifyTransporter
           it 'raises FailedLoginError with the right message and format' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
-            stub_login_call(mock_client, body: nil)
+            stub_login_call(mock_client, body: {not_the_right_key: 0})
 
-            expected_error_message = "Unable to obtain SOAP session ID from server.\n\nDetails:\n\n"
+            expected_error_message = "Unable to obtain SOAP session ID from server.\n\nDetails:\n{:not_the_right_key=>0}"
 
             expect { Soap.new(init_params).call(:test_call, {}) }.to raise_error(Soap::FailedLoginError, expected_error_message)
           end

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -43,14 +43,14 @@ module ShopifyTransporter
         end
 
         describe '#call' do
-          it 'initializes savon with the right parameters' do
+          it 'raises FailedLoginError if login response does not contain a session id' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
 
-            Soap.new(init_params).call(:test_call, {})
+            expect { Soap.new(init_params).call(:test_call, {}) }.to raise_error(Soap::FailedLoginError)
           end
 
-          it 'creates a session' do
+          it 'creates a session correctly if login response contains a session id' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
             stub_login_call(mock_client)

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -42,6 +42,13 @@ module ShopifyTransporter
           it 'raises FailedLoginError if login response does not contain a session id' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
+
+            expect { Soap.new(init_params).call(:test_call, {}) }.to raise_error(Soap::FailedLoginError)
+          end
+
+          it 'raises FailedLoginError with the right message and format' do
+            mock_client = spy('mock_client')
+            stub_client_call(mock_client)
             stub_login_call(mock_client, body: nil)
 
             expected_error_message = "Unable to obtain SOAP session ID from server.\n\nDetails:\n\n"
@@ -220,7 +227,7 @@ module ShopifyTransporter
               Processing batch: 3..5
               Skipping batch: 3..5 after 4 retries because of an error.
               The exact error was:
-              Savon::Error:
+              Savon::Error: 
               Soap call failed.
               Processing batch: 6..7
             WARNING


### PR DESCRIPTION
### What it does and why:

We need more detailed information if we want to be able to debug why people can't log in properly. This is Step 1 towards fixing that issue

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
https://github.com/Shopify/shopify_transporter/issues/111