### PR TITLE
Retrieve session id correctly from alternate login response from API

### DIFF
--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -91,7 +91,7 @@ module ShopifyTransporter
             }
           ).body
 
-          session_id = result&.dig(:login_response, :login_return)
+          session_id = result&.dig(:login_response, :login_return) || result&.dig(:login_response_param, :result)
           raise FailedLoginError, result.to_s unless session_id.present?
 
           @soap_session_id ||= session_id

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -56,10 +56,18 @@ module ShopifyTransporter
             expect { Soap.new(init_params).call(:test_call, {}) }.to raise_error(Soap::FailedLoginError, expected_error_message)
           end
 
-          it 'creates a session correctly if login response contains a session id' do
+          it 'creates a session correctly if the login response contains a session id in format A' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
             stub_login_call(mock_client)
+
+            Soap.new(init_params).call(:test_call, {})
+          end
+
+          it 'creates a session correctly if login response contains a session id in format B' do
+            mock_client = spy('mock_client')
+            stub_client_call(mock_client)
+            stub_login_call(mock_client, body: { login_response_param: { result: '456' } })
 
             Soap.new(init_params).call(:test_call, {})
           end
@@ -227,7 +235,7 @@ module ShopifyTransporter
               Processing batch: 3..5
               Skipping batch: 3..5 after 4 retries because of an error.
               The exact error was:
-              Savon::Error: 
+              Savon::Error:
               Soap call failed.
               Processing batch: 6..7
             WARNING

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -235,7 +235,7 @@ module ShopifyTransporter
               Processing batch: 3..5
               Skipping batch: 3..5 after 4 retries because of an error.
               The exact error was:
-              Savon::Error:
+              Savon::Error: 
               Soap call failed.
               Processing batch: 6..7
             WARNING

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -56,7 +56,7 @@ module ShopifyTransporter
             expect { Soap.new(init_params).call(:test_call, {}) }.to raise_error(Soap::FailedLoginError, expected_error_message)
           end
 
-          it 'creates a session correctly if the login response contains a session id in format A' do
+          it 'creates a session correctly if the login response has keys :login_response and :login_return' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
             stub_login_call(mock_client)
@@ -64,7 +64,7 @@ module ShopifyTransporter
             Soap.new(init_params).call(:test_call, {})
           end
 
-          it 'creates a session correctly if login response contains a session id in format B' do
+          it 'creates a session correctly if login response has keys :login_response_param and :result' do
             mock_client = spy('mock_client')
             stub_client_call(mock_client)
             stub_login_call(mock_client, body: { login_response_param: { result: '456' } })


### PR DESCRIPTION
### What it does and why:

Follow up PR to #112. Fixes #111 and #113.

Seems like the API somehow sometimes gives us the session ID in a weird format. I haven't found the root cause yet, but since it seems like this issue isn't exactly rare, we should implement a stopgap measure. So for now we will accept both formats.

I have no way to 🎩 this, since I have no access to a real store whose API responds this way. However, it passes tests and we'll have real life users testing it pretty quickly.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [ ] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:

#111 and #113 
