### PR TITLE
Convert special_price smartly to make compare_at_price work as expected

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
@@ -26,8 +26,8 @@ module ShopifyTransporter
 
             def accumulate(input)
               accumulate_attributes(map_from_key_to_val(COLUMN_MAPPING, input))
-              accumulate_attributes(variant_options(input))
               accumulate_attributes(map_from_key_to_val(price_mapping(input), input))
+              accumulate_attributes(variant_options(input))
             end
 
             private
@@ -37,18 +37,9 @@ module ShopifyTransporter
             end
 
             def price_mapping(input)
-              if input['special_price'].present?
-                special_price_foo(input)
-              else
-                { 'price' => 'price' }
-              end
-            end
+              return { 'price' => 'price' } unless input['special_price'].present?
 
-            def special_price_foo(input)
-              {
-                'special_price' => 'price',
-                'price' => 'compare_at_price',
-              }
+              { 'special_price' => 'price', 'price' => 'compare_at_price' }
             end
 
             def variant_options(input)

--- a/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
+++ b/lib/shopify_transporter/pipeline/magento/product/top_level_variant_attributes.rb
@@ -21,19 +21,34 @@ module ShopifyTransporter
             COLUMN_MAPPING = {
               'sku' => 'sku',
               'weight' => 'weight',
-              'price' => 'price',
               'inventory_quantity' => 'inventory_qty',
             }
 
             def accumulate(input)
               accumulate_attributes(map_from_key_to_val(COLUMN_MAPPING, input))
               accumulate_attributes(variant_options(input))
+              accumulate_attributes(map_from_key_to_val(price_mapping(input), input))
             end
 
             private
 
             def input_applies?(input)
               input.present? && input['type'] == 'simple'
+            end
+
+            def price_mapping(input)
+              if input['special_price'].present?
+                special_price_foo(input)
+              else
+                { 'price' => 'price' }
+              end
+            end
+
+            def special_price_foo(input)
+              {
+                'special_price' => 'price',
+                'price' => 'compare_at_price',
+              }
             end
 
             def variant_options(input)


### PR DESCRIPTION
### What it does and why:

Converts Magento `special_price` into Shopify's `compare_at_price` properly.

### Demo

In Magento:

![image](https://user-images.githubusercontent.com/7587265/48358977-d2033d80-e650-11e8-9000-c6128992eae4.png)

In Shopify:

![image](https://user-images.githubusercontent.com/7587265/48359108-23abc800-e651-11e8-96c9-0a32b1ad2dc2.png)

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:

https://github.com/Shopify/shopify_transporter/issues/109
