### PR TITLE
[R] force user to pass along scheme prefix in hostname

### DIFF
--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -74,7 +74,7 @@ module ShopifyTransporter
 
         def soap_client
           @soap_client ||= Savon.client(
-            wsdl: "https://#{@hostname}/api/v2_soap?wsdl",
+            wsdl: "#{@hostname}/api/v2_soap?wsdl",
             open_timeout: 500,
             read_timeout: 500,
           )

--- a/spec/shopify_transporter/exporters/magento/soap_spec.rb
+++ b/spec/shopify_transporter/exporters/magento/soap_spec.rb
@@ -7,7 +7,7 @@ module ShopifyTransporter
       RSpec.describe Soap do
         let(:init_params) do
           {
-            hostname: 'example.com',
+            hostname: 'https://example.com',
             username: 'testuser',
             api_key: 'testapikey',
             batch_config: {},


### PR DESCRIPTION
### What it does and why:

Instead of passing `magento-sandbox.myshopify.io` as the hostname, pass `https://magento-sandbox.myshopify.io` instead. This allows users to specify either `http` or `https` as their transfer protocol, for example.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
