### PR TITLE
[R] implement backwards compatible hostname scheme reader

### DIFF
--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -73,11 +73,19 @@ module ShopifyTransporter
         end
 
         def soap_client
+          default_scheme = 'https://'
+          hostname_with_scheme = protocol_provided?(@hostname) ? @hostname : default_scheme + @hostname
+
           @soap_client ||= Savon.client(
-            wsdl: "#{@hostname}/api/v2_soap?wsdl",
+            wsdl: "#{hostname_with_scheme}/api/v2_soap?wsdl",
             open_timeout: 500,
             read_timeout: 500,
           )
+        end
+
+        def protocol_provided?(address)
+          pattern = /(http)s?:\/\/.*/
+          (pattern =~ address) == 0
         end
 
         def soap_session_id

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -81,8 +81,7 @@ module ShopifyTransporter
         end
 
         def hostname_with_scheme
-          uri = URI.parse(@hostname)
-          uri.scheme.present? ? @hostname : 'https://' + @hostname
+          URI.parse(@hostname).scheme.present? ? @hostname : 'https://' + @hostname
         end
 
         def soap_session_id

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -73,9 +73,6 @@ module ShopifyTransporter
         end
 
         def soap_client
-          default_scheme = 'https://'
-          hostname_with_scheme = protocol_provided?(@hostname) ? @hostname : default_scheme + @hostname
-
           @soap_client ||= Savon.client(
             wsdl: "#{hostname_with_scheme}/api/v2_soap?wsdl",
             open_timeout: 500,
@@ -83,9 +80,9 @@ module ShopifyTransporter
           )
         end
 
-        def protocol_provided?(address)
-          pattern = %r{(http)s?:\/\/.*}
-          (pattern =~ address) == 0
+        def hostname_with_scheme
+          uri = URI.parse(@hostname)
+          uri.scheme.present? ? @hostname : 'https://' + @hostname
         end
 
         def soap_session_id

--- a/lib/shopify_transporter/exporters/magento/soap.rb
+++ b/lib/shopify_transporter/exporters/magento/soap.rb
@@ -84,7 +84,7 @@ module ShopifyTransporter
         end
 
         def protocol_provided?(address)
-          pattern = /(http)s?:\/\/.*/
+          pattern = %r{(http)s?:\/\/.*}
           (pattern =~ address) == 0
         end
 


### PR DESCRIPTION
### What it does and why:

Use a regex matcher to determine what format the hostname was provided in, and massages it into the right format. Assumes `https` as default transfer protocol if none is provided.

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes:
