### PR TITLE
Handle cases where configurable line item products don't exist during conversion

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/order/line_items.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/line_items.rb
@@ -26,12 +26,14 @@ module ShopifyTransporter
             line_items.group_by { |line_item| line_item['sku'] }.map do |_, associated_items|
               case associated_items.size
               when 1
-                associated_items.first
+                associated_items.first.except('product_type')
               when 2
                 parent = associated_items.find { |x| x['product_type'] == 'configurable' }
                 child = associated_items.find { |x| x['product_type'] == 'simple' }
-                parent.merge(child.slice('name'))
-              end.except('product_type')
+                next unless parent.present?
+
+                parent.merge(child.slice('name')).except('product_type')
+              end
             end
           end
 

--- a/lib/shopify_transporter/shopify/order.rb
+++ b/lib/shopify_transporter/shopify/order.rb
@@ -116,9 +116,11 @@ module ShopifyTransporter
       end
 
       def line_item_row_values
-        return [] unless record_hash['line_items']
+        return [] unless record_hash['line_items'].present?
 
         record_hash['line_items'].map do |line_item_hash|
+          next unless line_item_hash.present?
+
           line_item = line_item_hash.slice(*LINE_ITEM_ATTRIBUTES)
             .transform_keys { |k| "#{LINE_ITEM_PREFIX}#{k}" }
             .merge(tax_line_hash(line_item_hash))


### PR DESCRIPTION
### What it does and why:
- See title
### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/123
