### PR TITLE
Fix No implicit conversion of String into Integer TypeError in discount pipeline stage.

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/order/discounts.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/discounts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
 require 'shopify_transporter/shopify'
-
+require 'pry'
 module ShopifyTransporter
   module Pipeline
     module Magento
@@ -82,9 +82,12 @@ module ShopifyTransporter
           def qualifies_for_percentage_discount?(hash)
             return false unless line_items?(hash)
 
-            return true if line_items(hash).is_a?(Hash) && value_as_float(line_items(hash), 'discount_percent') > 0
-
-            all_discount_percentages(hash).length == 1 && all_discount_percentages(hash).first > 0
+            if line_items(hash).is_a?(Hash)
+              return true if value_as_float(line_items(hash), 'discount_percent') > 0
+              return false
+            else
+              all_discount_percentages(hash).length == 1 && all_discount_percentages(hash).first > 0
+            end
           end
 
           def line_items?(hash)

--- a/lib/shopify_transporter/pipeline/magento/order/discounts.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/discounts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
 require 'shopify_transporter/shopify'
-require 'pry'
+
 module ShopifyTransporter
   module Pipeline
     module Magento
@@ -83,8 +83,7 @@ module ShopifyTransporter
             return false unless line_items?(hash)
 
             if line_items(hash).is_a?(Hash)
-              return true if value_as_float(line_items(hash), 'discount_percent') > 0
-              return false
+              value_as_float(line_items(hash), 'discount_percent') > 0
             else
               all_discount_percentages(hash).length == 1 && all_discount_percentages(hash).first > 0
             end

--- a/spec/factories/magento/order.rb
+++ b/spec/factories/magento/order.rb
@@ -151,6 +151,15 @@ FactoryBot.define do
       end
     end
 
+    trait :with_zero_percentage_discount do
+      after(:build) do |order, evaluator|
+        order['items'] ||= {}
+        order['items']['result'] ||= {}
+        order['items']['result']['items'] ||= {}
+        order['items']['result']['items']['item'] ||= create(:magento_zero_percentage_discount)
+      end
+    end
+
     trait :with_percentage_discounts do
       after(:build) do |order, evaluator|
         order['discount_amount'] = '-15.00'
@@ -256,6 +265,12 @@ FactoryBot.define do
   factory :magento_percentage_discount, class: Hash do
     skip_create
     sequence(:discount_percent) { "25.00" }
+    initialize_with { attributes.deep_stringify_keys }
+  end
+
+  factory :magento_zero_percentage_discount, class: Hash do
+    skip_create
+    sequence(:discount_percent) { "0.00" }
     initialize_with { attributes.deep_stringify_keys }
   end
 end

--- a/spec/shopify_transporter/pipeline/magento/order/discounts_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/order/discounts_spec.rb
@@ -107,6 +107,19 @@ module ShopifyTransporter::Pipeline::Magento::Order
         ]
         expect(shopify_order['discounts']).to match_array(expected_discount_code)
       end
+
+      it 'should generate correct discount info when line_items is a singular hash instead of an array' do
+        magento_order = FactoryBot.build(:magento_order, :with_fixed_amount_discount, :with_zero_percentage_discount)
+        shopify_order = described_class.new.convert(magento_order, {})
+        expected_discount_code = [
+          {
+            amount: 15,
+            code: magento_order['discount_description'],
+            type: 'fixed_amount'
+          }.stringify_keys
+        ]
+        expect(shopify_order['discounts']).to eq(expected_discount_code)
+      end
     end
   end
 end


### PR DESCRIPTION
### What it does and why:
Properly handle the case where the `line_items` is a singular hash instead of an array.


### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/124
