### PR TITLE
Bug fix - No implicit conversion of Hash into String (TypeError)

### DIFF
--- a/lib/shopify_transporter/pipeline/magento/order/addresses_attribute.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/addresses_attribute.rb
@@ -23,10 +23,10 @@ module ShopifyTransporter
             result = items && items['result']
             address = result && result["#{prefix}address"]
             address ||= []
-            purge_address(input, address, prefix)
+            clean_address(input, address, prefix)
           end
 
-          def purge_address(input, address, prefix)
+          def clean_address(input, address, prefix)
             address.each_with_object({}) do |(key, val), purged_address|
               if val.is_a?(String)
                 purged_address[key] = val
@@ -59,7 +59,9 @@ module ShopifyTransporter
           end
 
           def name(address_attrs)
-            (address_attrs['firstname'].to_s + ' ' + address_attrs['lastname'].to_s).strip
+            if address_attrs['firstname'].present? && address_attrs['lastname'].present?
+              address_attrs['firstname'] + ' ' + address_attrs['lastname']
+            end
           end
         end
       end

--- a/lib/shopify_transporter/pipeline/magento/order/addresses_attribute.rb
+++ b/lib/shopify_transporter/pipeline/magento/order/addresses_attribute.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'shopify_transporter/pipeline/stage'
 require 'shopify_transporter/shopify'
-require 'pry'
+
 module ShopifyTransporter
   module Pipeline
     module Magento

--- a/spec/factories/magento/order.rb
+++ b/spec/factories/magento/order.rb
@@ -58,6 +58,24 @@ FactoryBot.define do
       end
     end
 
+    trait :with_billing_address_partially_in_unexpected_format do
+      after(:build) do |order, evaluator|
+        order['items'] ||= {}
+        order['items']['result'] ||= {}
+        order['items']['result']['billing_address'] = create(:magento_order_billing_address_with_nonsense)
+        order['items']
+      end
+    end
+
+    trait :with_shipping_address_partially_in_unexpected_format do
+      after(:build) do |order, evaluator|
+        order['items'] ||= {}
+        order['items']['result'] ||= {}
+        order['items']['result']['shipping_address'] = create(:magento_order_shipping_address_with_nonsense)
+        order['items']
+      end
+    end
+
     trait :with_qty_shipped do
       after(:build) do |order, evaluator|
         order['items'] ||= {}
@@ -212,6 +230,22 @@ FactoryBot.define do
     initialize_with { attributes.deep_stringify_keys }
   end
 
+  factory :magento_order_billing_address_with_nonsense, class: Hash do
+    skip_create
+
+    sequence(:firstname) { |n| "billing test first name-#{n}" }
+    sequence(:lastname) { {"@xsi:type": "xsd:string"} }
+    sequence(:telephone) { |n| "billing test telephone-#{n}" }
+    sequence(:street) { |n| "billing test street-#{n}" }
+    sequence(:city) { |n| "billing test city-#{n}" }
+    sequence(:region) { |n| "billing test region-#{n}" }
+    sequence(:postcode) { |n| "billing test postcode-#{n}" }
+    sequence(:country_id) { |n| "billing test country-#{n}" }
+    sequence(:company) { {"@xsi:type": "xsd:string"} }
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+
   factory :magento_order_shipping_address, class: Hash do
     skip_create
 
@@ -224,6 +258,22 @@ FactoryBot.define do
     sequence(:postcode) { |n| "shipping test postcode-#{n}" }
     sequence(:country_id) { |n| "shipping test country-#{n}" }
     sequence(:company) {|n| "shipping test company-#{n}"}
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+
+  factory :magento_order_shipping_address_with_nonsense, class: Hash do
+    skip_create
+
+    sequence(:firstname) { |n| "shipping test first name-#{n}" }
+    sequence(:lastname) { {"@xsi:type": "xsd:string"} }
+    sequence(:telephone) { {"@xsi:type": "xsd:string"} }
+    sequence(:street) { |n| "shipping test street-#{n}" }
+    sequence(:city) { |n| "shipping test city-#{n}" }
+    sequence(:region) { |n| "shipping test region-#{n}" }
+    sequence(:postcode) { |n| "shipping test postcode-#{n}" }
+    sequence(:country_id) { |n| "shipping test country-#{n}" }
+    sequence(:company) { {"@xsi:type": "xsd:string"} }
 
     initialize_with { attributes.deep_stringify_keys }
   end

--- a/spec/shopify_transporter/pipeline/magento/order/addresses_attribute_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/order/addresses_attribute_spec.rb
@@ -75,6 +75,41 @@ module ShopifyTransporter::Pipeline::Magento::Order
         }
         expect(shopify_order).to include(expected_shopify_addresses)
       end
+
+      it 'Will purge the address if it has nonsense key value pair' do
+        magento_order = FactoryBot.build(:magento_order, :with_billing_address_partially_in_unexpected_format,
+          :with_shipping_address_partially_in_unexpected_format)
+
+        shopify_order = described_class.new.convert(magento_order, {})
+
+        expected_shopify_addresses = {
+          "billing_address" => {
+            first_name: 'billing test first name-1',
+            last_name: nil,
+            name: 'billing test first name-1',
+            phone: 'billing test telephone-1',
+            address1: 'billing test street-1',
+            city: 'billing test city-1',
+            province_code: 'billing test region-1',
+            zip: 'billing test postcode-1',
+            country_code: 'billing test country-1',
+            company: nil,
+          },
+          "shipping_address" => {
+            first_name: 'shipping test first name-1',
+            last_name: nil,
+            name: 'shipping test first name-1',
+            phone: nil,
+            address1: 'shipping test street-1',
+            city: 'shipping test city-1',
+            province_code: 'shipping test region-1',
+            zip: 'shipping test postcode-1',
+            country_code: 'shipping test country-1',
+            company: nil,
+          }
+        }
+        expect(shopify_order).to include(expected_shopify_addresses)
+      end
     end
   end
 end

--- a/spec/shopify_transporter/pipeline/magento/order/addresses_attribute_spec.rb
+++ b/spec/shopify_transporter/pipeline/magento/order/addresses_attribute_spec.rb
@@ -86,7 +86,7 @@ module ShopifyTransporter::Pipeline::Magento::Order
           "billing_address" => {
             first_name: 'billing test first name-1',
             last_name: nil,
-            name: 'billing test first name-1',
+            name: nil,
             phone: 'billing test telephone-1',
             address1: 'billing test street-1',
             city: 'billing test city-1',
@@ -98,7 +98,7 @@ module ShopifyTransporter::Pipeline::Magento::Order
           "shipping_address" => {
             first_name: 'shipping test first name-1',
             last_name: nil,
-            name: 'shipping test first name-1',
+            name: nil,
             phone: nil,
             address1: 'shipping test street-1',
             city: 'shipping test city-1',


### PR DESCRIPTION
### What it does and why:
User's file has order address information in unexpected format. 
We expect the values (name, phone, fax, company, etc) to be string in the address hash, whereas in their file the value can be a nonsense hash like `{"@xsi:type": "xsd:string"}`.

This is most likely due to their customization of Magento allowing mandatory fields (like last name) to be empty and our XML phaser did the wrong move. However, Transporter CLI should not crash on such condition. The more elegant solution is to skip the troublesome fields and let the user know skipping happened. 

This pr adds the functionality to purge the address before the conversion step happens and prints a warning informing the user some fields get skipped due to unexpected format. 

Sample warning message:
```
Warning: Order 10003210 - telephone of the billing address is in an unexpected format. Transporter CLI expects it to be a string. Skipping telephone.
Warning: Order 10003210 - fax of the billing address is in an unexpected format. Transporter CLI expects it to be a string. Skipping fax.
```

### Checklist:

- [x] Testing & QA: Passes tests and linting.
- [x] :tophat:: I have manually tested these changes.

---

### Related issues:
Closes: https://github.com/Shopify/shopify_transporter/issues/130
