### PR TITLE
Update version to 2.5.2

### DIFF
--- a/lib/shopify_transporter/version.rb
+++ b/lib/shopify_transporter/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyTransporter
-  VERSION = '2.5.1'
+  VERSION = '2.5.2'
 end


### PR DESCRIPTION
### What it does and why:
- Bumps the gem version to 2.5.2 for a new release.
